### PR TITLE
[codex] raise bounded message view envelope

### DIFF
--- a/docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md
+++ b/docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md
@@ -392,3 +392,24 @@ code follow-up for production login availability.
 The post-V7 throttle transaction-locking follow-up closes the final explicit V7
 state-store race. Its implementation and evidence are recorded in
 `POST_V7_THROTTLE_TRANSACTION_LOCKING.md`.
+
+### Production Reevaluation: Bounded Message View Availability
+
+On 2026-06-19 UTC, authenticated production testing found that ordinary inbox
+messages with virtual sizes of 461,874 and 443,640 bytes returned a safe 503
+message-view response. A smaller 26,095-byte message rendered normally.
+Sanitized application evidence identified the cause as the 262,144-byte
+message-view body bound, not an nginx, session, authentication, or
+mailbox-helper outage.
+
+The message-view body bound is now 512 KiB. The mailbox-helper response bound is
+1 MiB so the maximum bounded body and protocol metadata remain transportable
+after base64 expansion. Both limits remain explicit and fail closed. Regression
+tests prove that a body at the message-view limit crosses the helper boundary
+successfully and a body one byte over the limit is rejected.
+
+This reevaluation preserves the V7 trust boundary while restoring expected
+availability for the observed production messages. Messages larger than
+512 KiB remain intentionally unavailable through message view and require a
+separate product decision if normal operations demonstrate a need for a larger
+bounded envelope.

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -827,6 +827,49 @@ mod tests {
     }
 
     #[test]
+    fn message_view_accepts_body_at_default_bound_and_rejects_one_byte_over() {
+        let bounded_body = "x".repeat(DEFAULT_MESSAGE_BODY_MAX_LEN);
+        let bounded = parse_doveadm_message_view_output(
+            MessageViewPolicy::default(),
+            &CommandExecution {
+                status_code: 0,
+                stdout: format!(
+                    "uid=9 flags=\"\" date.received=\"2026-06-20 00:00:00 +0000\" size.virtual={} mailbox=INBOX hdr=\"Subject: bounded\\n\" body=\"{}\"\n",
+                    bounded_body.len(),
+                    bounded_body
+                ),
+                stderr: String::new(),
+            },
+        )
+        .expect("body at the configured limit should parse");
+        assert_eq!(bounded.body_text.len(), DEFAULT_MESSAGE_BODY_MAX_LEN);
+
+        let oversized_body = "x".repeat(DEFAULT_MESSAGE_BODY_MAX_LEN + 1);
+        let error = parse_doveadm_message_view_output(
+            MessageViewPolicy::default(),
+            &CommandExecution {
+                status_code: 0,
+                stdout: format!(
+                    "uid=10 flags=\"\" date.received=\"2026-06-20 00:00:00 +0000\" size.virtual={} mailbox=INBOX hdr=\"Subject: oversized\\n\" body=\"{}\"\n",
+                    oversized_body.len(),
+                    oversized_body
+                ),
+                stderr: String::new(),
+            },
+        )
+        .expect_err("body above the configured limit must fail closed");
+
+        assert_eq!(error.backend, "message-view-parser");
+        assert_eq!(
+            error.reason,
+            format!(
+                "body exceeded maximum length of {} bytes",
+                DEFAULT_MESSAGE_BODY_MAX_LEN
+            )
+        );
+    }
+
+    #[test]
     fn rejects_message_list_output_missing_required_fields() {
         let error = parse_doveadm_message_list_output(
             MessageListPolicy::default(),

--- a/src/mailbox_helper.rs
+++ b/src/mailbox_helper.rs
@@ -58,7 +58,9 @@ use crate::openbsd::{apply_runtime_confinement, unix_stream_peer_uid};
 pub const DEFAULT_MAILBOX_HELPER_MAX_REQUEST_BYTES: usize = 4096;
 
 /// Conservative upper bound for one helper response payload.
-pub const DEFAULT_MAILBOX_HELPER_MAX_RESPONSE_BYTES: usize = 512 * 1024;
+///
+/// This includes base64 expansion of a maximum-size message-view body.
+pub const DEFAULT_MAILBOX_HELPER_MAX_RESPONSE_BYTES: usize = 1024 * 1024;
 
 /// Conservative per-connection read timeout for the helper socket.
 pub const DEFAULT_MAILBOX_HELPER_READ_TIMEOUT_SECS: u64 = 5;
@@ -1623,6 +1625,56 @@ mod tests {
         assert_eq!(message.uid, 12);
         assert_eq!(message.header_block, "Subject: Test message\n");
         assert_eq!(message.body_text, "Hello world\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn client_fetches_maximum_bounded_message_view_over_helper_socket() {
+        let socket_path = temp_socket_path("message-view-helper-max-body");
+        let body_text = "x".repeat(crate::mailbox::DEFAULT_MESSAGE_BODY_MAX_LEN);
+        let backend = StaticHelperBackend {
+            mailbox_result: Arc::new(Ok(Vec::new())),
+            message_list_result: Arc::new(Ok(Vec::new())),
+            message_search_result: Arc::new(Ok(Vec::new())),
+            message_view_result: Arc::new(Ok(MessageView {
+                mailbox_name: "INBOX".to_string(),
+                uid: 12,
+                flags: Vec::new(),
+                date_received: "2026-06-20 00:00:00 +0000".to_string(),
+                size_virtual: body_text.len() as u64,
+                header_block: "Subject: Bounded message\n".to_string(),
+                body_text: body_text.clone(),
+            })),
+            message_move_result: Arc::new(Ok(())),
+        };
+        let server = spawn_test_helper(socket_path.clone(), backend);
+        wait_for_socket(&socket_path);
+        let grant_key_path = temp_grant_key_path("message-view-helper-max-body");
+        let client = MailboxHelperMessageViewBackend::new(
+            &socket_path,
+            &grant_key_path,
+            MailboxHelperPolicy::default(),
+            MessageViewPolicy::default(),
+        );
+        let request = MessageViewRequest::new(MessageViewPolicy::default(), "INBOX", 12)
+            .expect("request should parse");
+
+        let message = client
+            .fetch_message("alice@example.com", &request)
+            .expect("maximum bounded message view should cross helper protocol");
+
+        server.join().expect("helper thread should finish");
+        let _ = fs::remove_file(&socket_path);
+        let _ = fs::remove_file(&grant_key_path);
+
+        assert_eq!(
+            message.body_text.len(),
+            crate::mailbox::DEFAULT_MESSAGE_BODY_MAX_LEN
+        );
+        assert_eq!(
+            MailboxHelperPolicy::default().max_response_bytes,
+            DEFAULT_MAILBOX_HELPER_MAX_RESPONSE_BYTES
+        );
     }
 
     #[cfg(unix)]

--- a/src/mailbox_model.rs
+++ b/src/mailbox_model.rs
@@ -28,8 +28,8 @@ pub const DEFAULT_SEARCH_HEADER_VALUE_MAX_LEN: usize = 512;
 /// Conservative maximum length for fetched message headers.
 pub const DEFAULT_MESSAGE_HEADER_MAX_LEN: usize = 65_536;
 
-/// Conservative maximum length for fetched message bodies in the first view slice.
-pub const DEFAULT_MESSAGE_BODY_MAX_LEN: usize = 262_144;
+/// Conservative maximum length for fetched message bodies.
+pub const DEFAULT_MESSAGE_BODY_MAX_LEN: usize = 512 * 1024;
 
 /// Policy controlling mailbox-output bounds for the first read-path slice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## What changed

- raise the bounded message-view body envelope from 256 KiB to 512 KiB
- raise the local mailbox-helper response envelope from 512 KiB to 1 MiB to accommodate base64 expansion
- add exact-boundary parser and helper transport regression tests
- record the production V7 reevaluation and residual limit

## Root cause

Authenticated production message views for ordinary messages sized 461,874 and 443,640 bytes failed with HTTP 503 because the MIME body exceeded the 262,144-byte message-view limit. Authentication, sessions, nginx, and the mailbox helper remained healthy.

## Security impact

Both layers remain explicitly bounded and fail closed. The change restores the affected normal inbox messages without removing resource limits or widening the browser trust boundary. Messages above 512 KiB remain unavailable by policy.

## Validation

- cargo fmt --check
- cargo test: 499 passed, 4 ignored, plus main, hostile-content, and doc tests
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make security-check
- targeted exact-boundary parser test
- targeted maximum bounded helper transport test