### PR TITLE
[codex] render Windows-1252 HTML mail

### DIFF
--- a/docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md
+++ b/docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md
@@ -413,3 +413,21 @@ availability for the observed production messages. Messages larger than
 512 KiB remain intentionally unavailable through message view and require a
 separate product decision if normal operations demonstrate a need for a larger
 bounded envelope.
+
+### Production Reevaluation: Windows-1252 Forwarded Message Rendering
+
+Authenticated production testing then found a forwarded Outlook message whose
+multipart HTML content and RFC 2047 subject used Windows-1252. OSMAP recognized
+that HTML was present but could not decode the charset, so the existing
+sanitized-HTML path received no body and returned a safe placeholder.
+
+OSMAP now decodes Windows-1252 and its `cp1252` alias through one internal,
+dependency-free charset boundary shared by MIME bodies, encoded headers, and
+RFC 2231 metadata. Undefined Windows-1252 byte positions become Unicode
+replacement characters rather than browser-visible controls. The decoded HTML
+still passes through the existing allowlist sanitizer, remote-content policy,
+rendered-size bound, and typed trusted-HTML boundary.
+
+A non-sensitive regression fixture proves that a quoted-printable,
+Windows-1252, HTML-only multipart forward renders its expected text, decodes
+its subject, and removes script content.

--- a/src/charset.rs
+++ b/src/charset.rs
@@ -1,0 +1,76 @@
+//! Narrow text charset decoding shared by MIME and header rendering.
+
+/// Decodes bytes from the explicitly supported browser-facing charset set.
+pub(crate) fn decode_text_bytes(charset: &str, bytes: &[u8]) -> Option<String> {
+    let charset = charset.trim().to_ascii_lowercase();
+    match charset.as_str() {
+        "utf-8" | "utf8" => String::from_utf8(bytes.to_vec()).ok(),
+        "us-ascii" | "ascii" => {
+            if bytes.is_ascii() {
+                Some(String::from_utf8_lossy(bytes).into_owned())
+            } else {
+                None
+            }
+        }
+        "iso-8859-1" | "latin1" | "latin-1" => {
+            Some(bytes.iter().map(|byte| char::from(*byte)).collect())
+        }
+        "windows-1252" | "cp1252" => Some(decode_windows_1252(bytes)),
+        _ => None,
+    }
+}
+
+fn decode_windows_1252(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .copied()
+        .map(|byte| match byte {
+            0x80 => '\u{20ac}',
+            0x82 => '\u{201a}',
+            0x83 => '\u{0192}',
+            0x84 => '\u{201e}',
+            0x85 => '\u{2026}',
+            0x86 => '\u{2020}',
+            0x87 => '\u{2021}',
+            0x88 => '\u{02c6}',
+            0x89 => '\u{2030}',
+            0x8a => '\u{0160}',
+            0x8b => '\u{2039}',
+            0x8c => '\u{0152}',
+            0x8e => '\u{017d}',
+            0x91 => '\u{2018}',
+            0x92 => '\u{2019}',
+            0x93 => '\u{201c}',
+            0x94 => '\u{201d}',
+            0x95 => '\u{2022}',
+            0x96 => '\u{2013}',
+            0x97 => '\u{2014}',
+            0x98 => '\u{02dc}',
+            0x99 => '\u{2122}',
+            0x9a => '\u{0161}',
+            0x9b => '\u{203a}',
+            0x9c => '\u{0153}',
+            0x9e => '\u{017e}',
+            0x9f => '\u{0178}',
+            0x81 | 0x8d | 0x8f | 0x90 | 0x9d => '\u{fffd}',
+            _ => char::from(byte),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_windows_1252_and_replaces_undefined_bytes() {
+        assert_eq!(
+            decode_text_bytes("Windows-1252", &[b'c', b'a', b'f', 0xe9, b' ', 0x96]),
+            Some("café –".to_string())
+        );
+        assert_eq!(
+            decode_text_bytes("cp1252", &[0x81]),
+            Some("\u{fffd}".to_string())
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod attachment;
 pub mod auth;
 pub mod bootstrap;
+mod charset;
 pub mod config;
 pub mod draft;
 pub mod error;

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -722,7 +722,7 @@ fn decode_text_body(
         _ => return Ok(None),
     };
 
-    Ok(decode_text_bytes_with_charset(
+    Ok(crate::charset::decode_text_bytes(
         content_type
             .params
             .get("charset")
@@ -828,25 +828,6 @@ fn decode_quoted_printable_text_bytes(input: &str) -> Option<Vec<u8>> {
     }
 
     Some(output)
-}
-
-/// Decodes text body bytes for a narrow set of common charsets.
-fn decode_text_bytes_with_charset(charset: &str, bytes: &[u8]) -> Option<String> {
-    let charset = charset.trim().to_ascii_lowercase();
-    match charset.as_str() {
-        "utf-8" | "utf8" => String::from_utf8(bytes.to_vec()).ok(),
-        "us-ascii" | "ascii" => {
-            if bytes.is_ascii() {
-                Some(String::from_utf8_lossy(bytes).into_owned())
-            } else {
-                None
-            }
-        }
-        "iso-8859-1" | "latin1" | "latin-1" => {
-            Some(bytes.iter().map(|byte| char::from(*byte)).collect())
-        }
-        _ => None,
-    }
 }
 
 /// Extracts one unfolded header value from a header block by case-insensitive name.
@@ -1062,7 +1043,7 @@ fn decode_rfc2231_continuation_parameter(
     }
 
     let decoded = match charset {
-        Some(charset) => decode_rfc2231_bytes_with_charset(&charset, &output),
+        Some(charset) => crate::charset::decode_text_bytes(&charset, &output),
         None => String::from_utf8(output).ok(),
     };
 
@@ -1088,7 +1069,7 @@ fn decode_rfc2231_encoded_bytes(
     let Some(decoded_bytes) = percent_decode_bytes(encoded_value) else {
         return Ok(None);
     };
-    let Some(decoded) = decode_rfc2231_bytes_with_charset(charset, &decoded_bytes) else {
+    let Some(decoded) = crate::charset::decode_text_bytes(charset, &decoded_bytes) else {
         return Ok(None);
     };
 
@@ -1123,26 +1104,6 @@ fn percent_decode_bytes(value: &str) -> Option<Vec<u8>> {
     }
 
     Some(output)
-}
-
-/// Decodes RFC 2231 parameter bytes for the same narrow charset set used by
-/// the header-summary renderer.
-fn decode_rfc2231_bytes_with_charset(charset: &str, bytes: &[u8]) -> Option<String> {
-    let charset = charset.trim().to_ascii_lowercase();
-    match charset.as_str() {
-        "utf-8" | "utf8" => String::from_utf8(bytes.to_vec()).ok(),
-        "us-ascii" | "ascii" => {
-            if bytes.is_ascii() {
-                Some(String::from_utf8_lossy(bytes).into_owned())
-            } else {
-                None
-            }
-        }
-        "iso-8859-1" | "latin1" | "latin-1" => {
-            Some(bytes.iter().map(|byte| char::from(*byte)).collect())
-        }
-        _ => None,
-    }
 }
 
 /// Decodes one hexadecimal ASCII nibble used by RFC 2231 percent encoding.

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -345,7 +345,7 @@ fn parse_encoded_word(input: &str) -> Option<(usize, String)> {
         b'Q' | b'q' => decode_header_q_encoding(encoded_text).ok()?,
         _ => return None,
     };
-    let decoded_text = decode_header_bytes_with_charset(charset, &decoded_bytes)?;
+    let decoded_text = crate::charset::decode_text_bytes(charset, &decoded_bytes)?;
 
     Some((encoded_end + 2, decoded_text))
 }
@@ -429,25 +429,6 @@ fn decode_header_base64(input: &str) -> Result<Vec<u8>, ()> {
     }
 
     Ok(output)
-}
-
-/// Decodes header bytes for a narrow set of common charsets.
-fn decode_header_bytes_with_charset(charset: &str, bytes: &[u8]) -> Option<String> {
-    let charset = charset.trim().to_ascii_lowercase();
-    match charset.as_str() {
-        "utf-8" | "utf8" => String::from_utf8(bytes.to_vec()).ok(),
-        "us-ascii" | "ascii" => {
-            if bytes.is_ascii() {
-                Some(String::from_utf8_lossy(bytes).into_owned())
-            } else {
-                None
-            }
-        }
-        "iso-8859-1" | "latin1" | "latin-1" => {
-            Some(bytes.iter().map(|byte| char::from(*byte)).collect())
-        }
-        _ => None,
-    }
 }
 
 /// Decodes one hexadecimal ASCII nibble used by RFC 2047 Q encoding.
@@ -1001,6 +982,38 @@ mod tests {
         assert!(outcome.rendered.body_html.contains("<b>world</b>"));
         assert!(outcome.rendered.body_text_for_compose.contains("Hello"));
         assert!(outcome.rendered.body_text_for_compose.contains("world"));
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+    }
+
+    #[test]
+    fn fixture_windows_1252_html_only_forward_renders_sanitized_content() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/windows_1252_html_only_forward.eml"
+        ));
+
+        let outcome = renderer
+            .render_for_validated_session(&test_context(), &validated_session_fixture(), &message)
+            .expect("windows-1252 HTML-only forward should render safely");
+
+        assert_eq!(
+            outcome.rendered.subject.as_deref(),
+            Some("Forwarded café – update")
+        );
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartHtmlSanitized
+        );
+        assert!(outcome.rendered.body_html.contains(concat!(
+            "Forwarded café ",
+            "\u{2014}",
+            " expected content."
+        )));
+        assert!(!outcome.rendered.body_html.contains("<script"));
+        assert!(!outcome.rendered.body_html.contains("alert(1)"));
         assert_eq!(
             outcome.rendered.rendering_mode,
             RenderingMode::SanitizedHtml

--- a/tests/fixtures/mime/unsupported_charset_html.eml
+++ b/tests/fixtures/mime/unsupported_charset_html.eml
@@ -1,6 +1,6 @@
-Subject: Legacy charset HTML
-From: Legacy Sender <legacy@example.org>
-Content-Type: text/html; charset=windows-1252
+Subject: Unsupported charset HTML
+From: Unsupported Sender <unsupported@example.org>
+Content-Type: text/html; charset=koi8-r
 Content-Transfer-Encoding: quoted-printable
 
-<p>Smart quote =93test=94</p>
+<p>=F0=D2=C9=D7=C5=D4</p>

--- a/tests/fixtures/mime/windows_1252_html_only_forward.eml
+++ b/tests/fixtures/mime/windows_1252_html_only_forward.eml
@@ -1,0 +1,10 @@
+Subject: =?Windows-1252?Q?Forwarded_caf=E9_=96_update?=
+From: Example Sender <sender@example.invalid>
+Content-Type: multipart/alternative; boundary="windows-alt"
+
+--windows-alt
+Content-Type: text/html; charset=Windows-1252
+Content-Transfer-Encoding: quoted-printable
+
+<html><body><p>Forwarded caf=E9 =97 expected content.</p><script>alert(1)</script></body></html>
+--windows-alt--


### PR DESCRIPTION
## What changed

- add dependency-free Windows-1252 and cp1252 decoding at one internal charset boundary
- reuse it for MIME bodies, RFC 2047 encoded headers, and RFC 2231 metadata
- replace undefined Windows-1252 positions with Unicode replacement characters
- add a non-sensitive Outlook-style HTML-only forwarding fixture
- preserve a genuinely unsupported charset fail-closed fixture
- record the production V7 reevaluation

## Root cause

Production UID 297 was retrieved successfully and marked as multipart HTML, but rendered a placeholder. Its quoted-printable body and encoded subject declared Windows-1252. OSMAP did not support that charset, so MIME analysis could not provide the HTML body to the existing sanitizer.

## Security impact

The change only decodes a common legacy charset before the existing rendering boundary. Decoded HTML still passes through the allowlist sanitizer, remote-content blocking, rendered-size limit, and typed trusted-HTML boundary. No dependency or browser capability was added.

## Validation

- production logs confirmed prefer_sanitized_html with multipart_html_withheld
- targeted Windows-1252 HTML-only forward fixture passes
- script content is removed by the sanitizer
- unsupported charset remains withheld
- cargo test: 501 passed, 4 ignored, plus main, hostile-content, and doc tests
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make security-check