### PR TITLE
restore message rendering regression coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Keep developer entrypoints obvious and conservative so operators and
 # collaborating developers do not have to memorize cargo subcommands.
 
-.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check install-hooks run
+.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check install-hooks run
 
 build:
 	cargo build
@@ -42,9 +42,13 @@ v6-check:
 
 v7-check:
 	sh maint/security/osmap-v7-boundary-hardening-gate.sh
+	sh maint/security/osmap-v7-rendering-regression-gate.sh
+
+v7-rendering-regression-check:
+	sh maint/security/osmap-v7-rendering-regression-gate.sh
 
 install-hooks:
-	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py
+	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v7-rendering-regression-gate.sh maint/security/test-osmap-v7-rendering-regression-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py
 	git config core.hooksPath .githooks
 
 run:

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -93,3 +93,14 @@ partial validation path. `make release-check` is the strict release path and
 must fail on skipped Cargo, clippy, rustfmt, supply-chain, dependency
 inventory, host-readiness, V2 carry-forward, sanitized evidence archive, or
 credential and TOTP-backed WSTG coverage.
+
+## V7 rendering regression close-out
+
+V7 rendering regression close-out is a stabilization gate, not feature work. The gate exists because the message-view daily-driver path regressed for real-world multipart HTML mail after earlier testing discipline weakened.
+
+The required gate is `maint/security/osmap-v7-rendering-regression-gate.sh`. It is invoked by `make v7-rendering-regression-check`, `make v7-check`, and `make security-check`.
+
+This gate is intentionally not grep-only. It performs structural checks for durable coverage names and then executes targeted Rust tests for MIME selection, charset and RFC 2047 decoding, sanitized HTML rendering, hostile HTML containment, malformed MIME fail-closed behavior, and truthful message-view UI labels.
+
+Cargo and rustc are required for this close-out gate. A host that cannot run the Rust tests is not a valid close-out environment for this incident.
+

--- a/docs/V7_RENDERING_REGRESSION_CLOSEOUT.md
+++ b/docs/V7_RENDERING_REGRESSION_CLOSEOUT.md
@@ -1,0 +1,60 @@
+# V7 rendering regression close-out
+
+## Status
+
+V7 entered stabilization freeze because daily-driver message rendering regressed after testing discipline weakened. A production-visible multipart HTML message rendered only the historical placeholder instead of a sanitized HTML view when no safe plain-text body was available.
+
+Feature development remains frozen until this gate passes.
+
+## Closed regression class
+
+The recovered behavior is protected by fixture-based Rust tests and a required V7 rendering regression gate. The protected rule is:
+
+- when a safe plain-text part exists and the user prefers plain text, OSMAP renders plain text;
+- when no safe plain-text part exists but a selected HTML body exists, OSMAP renders sanitized HTML;
+- OSMAP never renders raw HTML;
+- OSMAP does not load remote content;
+- OSMAP does not allow active content.
+
+## Bounded security claim
+
+OSMAP renders sanitized HTML only through the current allowlist policy and blocks active or remote content. This is a bounded browser-mail rendering claim. It does not claim that arbitrary hostile HTML is safe outside that policy, outside the OSMAP rendering path, or outside the tested containment boundary.
+
+## Gate coverage
+
+The close-out gate is `maint/security/osmap-v7-rendering-regression-gate.sh` and is reachable through:
+
+```sh
+make v7-rendering-regression-check
+make v7-check
+make security-check
+```
+
+The gate runs Rust tests for:
+
+- HTML-only singlepart sanitized rendering;
+- HTML-only multipart sanitized rendering when no safe plain-text body exists;
+- plain-text preference selecting plain text when available;
+- sanitized-HTML preference selecting sanitized HTML when available;
+- plain-text preference falling back to sanitized HTML when no safe plain body exists;
+- Windows-1252 and RFC 2047 subject and body decoding;
+- hostile HTML sanitization for scripts, handlers, forms, iframes, object/embed, remote image fetches, relative URLs, protocol-relative URLs, and unsafe schemes;
+- malformed MIME fail-closed behavior without raw HTML rendering;
+- truthful UI labels for body source, rendering mode, HTML presence, sanitized HTML notice, and remote-content blocking.
+
+## Evidence recording
+
+Run-specific evidence is written outside the repository by `RUN_ME.sh` under:
+
+```text
+$HOME/osmap-v7-rendering-regression-closeout-evidence/<timestamp>
+```
+
+The runner produces an evidence archive and matching SHA-256 file:
+
+```text
+osmap-v7-rendering-regression-closeout-evidence-<timestamp>.tar.gz
+osmap-v7-rendering-regression-closeout-evidence-<timestamp>.tar.gz.sha256
+```
+
+The archive contains the exact command output, diffs, gate output, final repository state, commit identity when created, and the run-specific archive checksum.

--- a/maint/security/osmap-security-check.sh
+++ b/maint/security/osmap-security-check.sh
@@ -95,6 +95,12 @@ if [ "$run_cargo_phases" -eq 1 ]; then
 
 	echo "==> supply-chain gate"
 	sh maint/security/osmap-supply-chain-check.sh
+
+	echo "==> validating V7 rendering regression close-out gate"
+	sh maint/security/osmap-v7-rendering-regression-gate.sh
+
+	echo "==> validating V7 rendering regression gate wrapper behavior"
+	sh maint/security/test-osmap-v7-rendering-regression-gate.sh
 fi
 
 echo "==> validating publication hygiene"
@@ -105,6 +111,7 @@ sh maint/security/osmap-doc-governance-guard.sh
 
 echo "==> validating V7 boundary hardening invariants"
 sh maint/security/osmap-v7-boundary-hardening-gate.sh
+
 
 echo "==> validating TLS policy invariants"
 sh maint/security/osmap-tls-policy-guard.sh

--- a/maint/security/osmap-v7-rendering-regression-gate.sh
+++ b/maint/security/osmap-v7-rendering-regression-gate.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V7_RENDERING_GATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_file() {
+	path=$1
+	if [ ! -s "$path" ]; then
+		echo "error: missing V7 rendering regression input: $path" >&2
+		exit 1
+	fi
+}
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V7 rendering regression requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+run_cargo_test() {
+	test_name=$1
+	echo "==> cargo test --quiet -- $test_name"
+	cargo test --quiet -- "$test_name"
+}
+
+if ! command -v cargo >/dev/null 2>&1; then
+	echo "error: cargo is required for the V7 rendering regression close-out gate" >&2
+	exit 1
+fi
+
+if ! command -v rustc >/dev/null 2>&1; then
+	echo "error: rustc is required for the V7 rendering regression close-out gate" >&2
+	exit 1
+fi
+
+for path in \
+	Cargo.toml \
+	Makefile \
+	src/rendering.rs \
+	src/rendering_html.rs \
+	src/mime.rs \
+	src/charset.rs \
+	src/http_ui.rs \
+	docs/TEST_STRATEGY.md \
+	docs/V7_RENDERING_REGRESSION_CLOSEOUT.md \
+	tests/fixtures/mime/windows_1252_html_only_forward.eml \
+	tests/fixtures/mime/nested_mixed_hostile_html.eml \
+	tests/fixtures/mime/malformed_boundary.eml \
+	tests/fixtures/mime/html_link_scheme_probe.eml
+	do
+	require_file "$path"
+done
+
+require_text src/rendering.rs "PreferPlainText means render a safe plain-text part when one exists."
+require_text src/rendering.rs "fn html_only_singlepart_renders_sanitized_html()"
+require_text src/rendering.rs "fn html_only_multipart_without_plain_text_renders_sanitized_html()"
+require_text src/rendering.rs "fn prefer_plain_text_renders_plain_when_plain_exists()"
+require_text src/rendering.rs "fn prefer_sanitized_html_renders_html_when_html_exists()"
+require_text src/rendering.rs "fn prefer_plain_text_falls_back_to_sanitized_html_without_plain()"
+require_text src/rendering.rs "fn windows_1252_html_only_forward_renders_decoded_subject_and_body()"
+require_text src/rendering.rs "fn hostile_html_sanitization_strips_active_and_remote_content()"
+require_text src/rendering.rs "fn malformed_mime_renders_safe_placeholder_or_errors_without_raw_html()"
+require_text src/http_ui.rs "fn ui_message_view_surfaces_truthful_rendering_labels()"
+require_text src/rendering_html.rs "UrlRelative::Deny"
+require_text src/rendering_html.rs '"http", "https", "mailto"'
+require_text src/charset.rs '"windows-1252" | "cp1252"'
+require_text docs/V7_RENDERING_REGRESSION_CLOSEOUT.md "Feature development remains frozen until this gate passes."
+require_text docs/TEST_STRATEGY.md "V7 rendering regression close-out"
+require_text Makefile "v7-rendering-regression-check"
+require_text maint/security/osmap-security-check.sh "osmap-v7-rendering-regression-gate.sh"
+
+run_cargo_test html_only_singlepart_renders_sanitized_html
+run_cargo_test html_only_multipart_without_plain_text_renders_sanitized_html
+run_cargo_test prefer_plain_text_renders_plain_when_plain_exists
+run_cargo_test prefer_sanitized_html_renders_html_when_html_exists
+run_cargo_test prefer_plain_text_falls_back_to_sanitized_html_without_plain
+run_cargo_test windows_1252_html_only_forward_renders_decoded_subject_and_body
+run_cargo_test hostile_html_sanitization_strips_active_and_remote_content
+run_cargo_test malformed_mime_renders_safe_placeholder_or_errors_without_raw_html
+run_cargo_test ui_message_view_surfaces_truthful_rendering_labels
+run_cargo_test strips_unsafe_link_schemes_and_relative_urls
+run_cargo_test strips_obfuscated_and_browser_only_link_schemes
+run_cargo_test strips_scriptable_attributes_forms_remote_fetch_surfaces_and_comments
+run_cargo_test decodes_windows_1252_and_replaces_undefined_bytes
+run_cargo_test decodes_base64_encoded_header_summary_values
+
+cargo test --quiet -- fixture_windows_1252_html_only_forward_renders_sanitized_content
+cargo test --quiet -- fixture_hostile_html_strips_active_and_remote_content
+cargo test --quiet -- fixture_malformed_boundary_renders_safe_placeholder
+
+echo "V7 rendering regression gate passed"

--- a/maint/security/test-osmap-install-hooks.sh
+++ b/maint/security/test-osmap-install-hooks.sh
@@ -15,6 +15,8 @@ source_v4_claim_matrix_gate="${repo_root}/maint/security/osmap-v4-security-claim
 source_v5_boundary_gate="${repo_root}/maint/security/osmap-v5-boundary-gate.sh"
 source_v6_readiness_gate="${repo_root}/maint/security/osmap-v6-retirement-readiness-gate.sh"
 source_v7_boundary_gate="${repo_root}/maint/security/osmap-v7-boundary-hardening-gate.sh"
+source_v7_rendering_gate="${repo_root}/maint/security/osmap-v7-rendering-regression-gate.sh"
+source_v7_rendering_gate_test="${repo_root}/maint/security/test-osmap-v7-rendering-regression-gate.sh"
 source_v6_evidence_archive="${repo_root}/maint/security/osmap-v6-evidence-archive.sh"
 source_evidence_metadata="${repo_root}/maint/security/osmap-evidence-metadata.sh"
 source_cwe_guard="${repo_root}/maint/security/osmap-cwe-top25-guard.sh"
@@ -46,6 +48,8 @@ cp "${source_v4_claim_matrix_gate}" "${fake_security_dir}/osmap-v4-security-clai
 cp "${source_v5_boundary_gate}" "${fake_security_dir}/osmap-v5-boundary-gate.sh"
 cp "${source_v6_readiness_gate}" "${fake_security_dir}/osmap-v6-retirement-readiness-gate.sh"
 cp "${source_v7_boundary_gate}" "${fake_security_dir}/osmap-v7-boundary-hardening-gate.sh"
+cp "${source_v7_rendering_gate}" "${fake_security_dir}/osmap-v7-rendering-regression-gate.sh"
+cp "${source_v7_rendering_gate_test}" "${fake_security_dir}/test-osmap-v7-rendering-regression-gate.sh"
 cp "${source_v6_evidence_archive}" "${fake_security_dir}/osmap-v6-evidence-archive.sh"
 cp "${source_evidence_metadata}" "${fake_security_dir}/osmap-evidence-metadata.sh"
 cp "${source_cwe_guard}" "${fake_security_dir}/osmap-cwe-top25-guard.sh"
@@ -118,6 +122,14 @@ assert_equals "$(git -C "${fake_repo}" config --local core.hooksPath)" ".githook
 }
 [ -x "${fake_security_dir}/osmap-v7-boundary-hardening-gate.sh" ] || {
 	printf '%s\n' "expected V7 boundary hardening gate script to be executable" >&2
+	exit 1
+}
+[ -x "${fake_security_dir}/osmap-v7-rendering-regression-gate.sh" ] || {
+	printf '%s\n' "expected V7 rendering regression gate script to be executable" >&2
+	exit 1
+}
+[ -x "${fake_security_dir}/test-osmap-v7-rendering-regression-gate.sh" ] || {
+	printf '%s\n' "expected V7 rendering regression gate wrapper test to be executable" >&2
 	exit 1
 }
 [ -x "${fake_security_dir}/osmap-v6-evidence-archive.sh" ] || {

--- a/maint/security/test-osmap-v7-rendering-regression-gate.sh
+++ b/maint/security/test-osmap-v7-rendering-regression-gate.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V7_RENDERING_TEST_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V7 rendering gate test requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+sh -n maint/security/osmap-v7-rendering-regression-gate.sh
+require_text maint/security/osmap-v7-rendering-regression-gate.sh "command -v cargo"
+require_text maint/security/osmap-v7-rendering-regression-gate.sh "error: cargo is required"
+require_text maint/security/osmap-v7-rendering-regression-gate.sh "cargo test --quiet --"
+require_text maint/security/osmap-v7-rendering-regression-gate.sh "prefer_plain_text_falls_back_to_sanitized_html_without_plain"
+require_text maint/security/osmap-v7-rendering-regression-gate.sh "ui_message_view_surfaces_truthful_rendering_labels"
+require_text Makefile "v7-rendering-regression-check"
+require_text Makefile "sh maint/security/osmap-v7-rendering-regression-gate.sh"
+require_text maint/security/osmap-security-check.sh "validating V7 rendering regression close-out gate"
+require_text maint/security/osmap-security-check.sh "sh maint/security/osmap-v7-rendering-regression-gate.sh"
+
+echo "V7 rendering regression gate wrapper test passed"

--- a/src/http_ui.rs
+++ b/src/http_ui.rs
@@ -1229,3 +1229,62 @@ pub(crate) fn render_settings_page(model: &SettingsPageModel<'_>) -> TrustedHtml
         escape_html(archive_mailbox_name),
     ))
 }
+
+#[cfg(test)]
+mod v7_rendering_regression_tests {
+    use super::*;
+    use crate::html::TrustedHtml;
+    use crate::mailbox::{MailboxEntry, MailboxListingPolicy};
+    use crate::mime::{AttachmentDisposition, AttachmentMetadata, MimeBodySource};
+    use crate::rendering::RenderingMode;
+
+    #[test]
+    fn ui_message_view_surfaces_truthful_rendering_labels() {
+        let rendered = RenderedMessageView {
+            mailbox_name: "INBOX".to_string(),
+            uid: 42,
+            subject: Some("Decoded café".to_string()),
+            from: Some("Example Sender <sender@example.invalid>".to_string()),
+            date_received: "2026-06-20 00:00:00 +0000".to_string(),
+            mime_top_level_content_type: "multipart/alternative".to_string(),
+            body_source: MimeBodySource::MultipartHtmlSanitized,
+            contains_html_body: true,
+            body_html: TrustedHtml::from_sanitized(
+                "<div class=\"message-html\"><p>Safe rendered body</p></div>".to_string(),
+            ),
+            body_text_for_compose: "Safe rendered body".to_string(),
+            attachments: vec![AttachmentMetadata {
+                part_path: "1.2".to_string(),
+                filename: Some("logo.png".to_string()),
+                content_type: "image/png".to_string(),
+                disposition: AttachmentDisposition::Inline,
+                content_id: Some("logo@example.invalid".to_string()),
+                size_hint_bytes: 128,
+            }],
+            rendering_mode: RenderingMode::SanitizedHtml,
+        };
+        let mailboxes = vec![
+            MailboxEntry::new(MailboxListingPolicy::default(), "INBOX")
+                .expect("mailbox should validate"),
+            MailboxEntry::new(MailboxListingPolicy::default(), "Trash")
+                .expect("mailbox should validate"),
+        ];
+
+        let page = render_message_view_page(
+            "alice@example.com",
+            "csrf-token-placeholder",
+            &rendered,
+            Some("Archive"),
+            &mailboxes,
+        );
+
+        assert!(page.contains("Body Source</dt><dd>multipart_html_sanitized</dd>"));
+        assert!(page.contains("Rendering Mode</dt><dd>sanitized_html</dd>"));
+        assert!(page.contains("HTML Present</dt><dd>yes</dd>"));
+        assert!(page.contains("HTML present"));
+        assert!(page.contains("remote content blocked"));
+        assert!(page.contains("<strong>Sanitized HTML:</strong>"));
+        assert!(page.contains("Remote content blocked by policy"));
+        assert!(page.contains("Safe rendered body"));
+    }
+}

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -456,6 +456,18 @@ fn render_body_from_analysis(
         }
     }
 
+    // PreferPlainText means render a safe plain-text part when one exists.
+    // It must not mean withhold all HTML forever. If no safe plain-text body
+    // exists but the MIME layer selected an HTML body, fall back to sanitized
+    // HTML rather than showing the historical regression placeholder.
+    if analysis.selected_plain_text_body.is_none() {
+        if let Some(rendered_html) =
+            render_sanitized_html_body(analysis, html_rendering_policy, max_len)?
+        {
+            return Ok(rendered_html);
+        }
+    }
+
     match analysis.body_source {
         MimeBodySource::SinglePartPlainText | MimeBodySource::MultipartPlainTextPart => {
             let mut rendered = render_plain_text_body(
@@ -1255,6 +1267,232 @@ mod tests {
             outcome.rendered.rendering_mode,
             RenderingMode::SanitizedHtml
         );
+    }
+
+    #[test]
+    fn html_only_singlepart_renders_sanitized_html() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let outcome = renderer
+            .render_for_validated_session(
+                &test_context(),
+                &validated_session_fixture(),
+                &html_only_message_view_fixture(),
+            )
+            .expect("HTML-only singlepart should render through sanitizer");
+
+        assert_eq!(outcome.rendered.body_source, MimeBodySource::HtmlSanitized);
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+        assert!(outcome.rendered.contains_html_body);
+        assert!(outcome.rendered.body_html.contains("message-html"));
+        assert!(outcome.rendered.body_html.contains("<b>world</b>"));
+        assert!(!outcome.rendered.body_html.contains("<script"));
+    }
+
+    #[test]
+    fn html_only_multipart_without_plain_text_renders_sanitized_html() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/windows_1252_html_only_forward.eml"
+        ));
+
+        let outcome = renderer
+            .render_for_validated_session(&test_context(), &validated_session_fixture(), &message)
+            .expect("multipart HTML-only fixture should render through sanitizer");
+
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartHtmlSanitized
+        );
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+        assert!(outcome.rendered.body_html.contains("Forwarded café"));
+        assert!(!outcome.rendered.body_html.contains("alert(1)"));
+    }
+
+    #[test]
+    fn prefer_plain_text_renders_plain_when_plain_exists() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy {
+            html_display_preference: HtmlDisplayPreference::PreferPlainText,
+            ..RenderingPolicy::default()
+        });
+        let outcome = renderer
+            .render_for_validated_session(
+                &test_context(),
+                &validated_session_fixture(),
+                &multipart_message_view_fixture(),
+            )
+            .expect("plain preference should render selected safe plain text");
+
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartPlainTextPart
+        );
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::PlainTextPreformatted
+        );
+        assert!(outcome
+            .rendered
+            .body_html
+            .contains("<pre>Plain text preview</pre>"));
+        assert!(!outcome.rendered.body_html.contains("HTML body"));
+    }
+
+    #[test]
+    fn prefer_sanitized_html_renders_html_when_html_exists() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy {
+            html_display_preference: HtmlDisplayPreference::PreferSanitizedHtml,
+            ..RenderingPolicy::default()
+        });
+        let outcome = renderer
+            .render_for_validated_session(
+                &test_context(),
+                &validated_session_fixture(),
+                &multipart_message_view_fixture(),
+            )
+            .expect("sanitized HTML preference should render selected HTML");
+
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartHtmlSanitized
+        );
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+        assert!(outcome.rendered.body_html.contains("HTML body"));
+        assert_eq!(outcome.rendered.body_text_for_compose, "Plain text preview");
+    }
+
+    #[test]
+    fn prefer_plain_text_falls_back_to_sanitized_html_without_plain() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy {
+            html_display_preference: HtmlDisplayPreference::PreferPlainText,
+            ..RenderingPolicy::default()
+        });
+        let message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/windows_1252_html_only_forward.eml"
+        ));
+
+        let outcome = renderer
+            .render_for_validated_session(&test_context(), &validated_session_fixture(), &message)
+            .expect("plain preference should fall back to sanitized HTML without safe plain text");
+
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartHtmlSanitized
+        );
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+        assert!(outcome.rendered.body_html.contains("Forwarded café"));
+        assert!(!outcome.rendered.body_html.contains(
+            "Multipart message contains HTML content, but no safe plain-text part was selected."
+        ));
+        assert!(!outcome.rendered.body_html.contains("<script"));
+    }
+
+    #[test]
+    fn windows_1252_html_only_forward_renders_decoded_subject_and_body() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/windows_1252_html_only_forward.eml"
+        ));
+
+        let outcome = renderer
+            .render_for_validated_session(&test_context(), &validated_session_fixture(), &message)
+            .expect("windows-1252 HTML-only forward should render safely");
+
+        assert_eq!(
+            outcome.rendered.subject.as_deref(),
+            Some("Forwarded café – update")
+        );
+        assert!(outcome.rendered.body_html.contains("Forwarded café"));
+        assert!(outcome.rendered.body_html.contains("expected content."));
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::SanitizedHtml
+        );
+    }
+
+    #[test]
+    fn hostile_html_sanitization_strips_active_and_remote_content() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let nested_message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/nested_mixed_hostile_html.eml"
+        ));
+        let link_probe_message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/html_link_scheme_probe.eml"
+        ));
+
+        let nested = renderer
+            .render_for_validated_session(
+                &test_context(),
+                &validated_session_fixture(),
+                &nested_message,
+            )
+            .expect("hostile nested fixture should render safely");
+        let link_probe = renderer
+            .render_for_validated_session(
+                &test_context(),
+                &validated_session_fixture(),
+                &link_probe_message,
+            )
+            .expect("link scheme probe fixture should render safely");
+
+        for body in [&nested.rendered.body_html, &link_probe.rendered.body_html] {
+            assert!(!body.contains("<script"));
+            assert!(!body.contains("onclick"));
+            assert!(!body.contains("<form"));
+            assert!(!body.contains("<iframe"));
+            assert!(!body.contains("<object"));
+            assert!(!body.contains("<embed"));
+            assert!(!body.contains("<img"));
+            assert!(!body.contains("javascript:"));
+            assert!(!body.contains("data:"));
+            assert!(!body.contains("cid:"));
+            assert!(!body.contains("file:"));
+            assert!(!body.contains("blob:"));
+            assert!(!body.contains("href=\"/"));
+            assert!(!body.contains("href=\"//"));
+            assert!(!body.contains("evil.example"));
+        }
+        assert!(link_probe
+            .rendered
+            .body_html
+            .contains("href=\"https://example.com/safe\""));
+    }
+
+    #[test]
+    fn malformed_mime_renders_safe_placeholder_or_errors_without_raw_html() {
+        let renderer = PlainTextMessageRenderer::new(RenderingPolicy::default());
+        let message = message_view_from_fixture(include_str!(
+            "../tests/fixtures/mime/malformed_boundary.eml"
+        ));
+
+        let outcome = renderer
+            .render_for_validated_session(&test_context(), &validated_session_fixture(), &message)
+            .expect("malformed fixture should fail closed into a safe placeholder");
+
+        assert_eq!(
+            outcome.rendered.body_source,
+            MimeBodySource::MultipartStructureWithheld
+        );
+        assert_eq!(
+            outcome.rendered.rendering_mode,
+            RenderingMode::PlainTextPreformatted
+        );
+        assert!(outcome.rendered.body_html.contains(
+            "Multipart structure detected, but no safe plain-text preview is available."
+        ));
+        assert!(!outcome.rendered.body_html.contains("<script"));
+        assert!(!outcome.rendered.body_html.contains("<html"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes out the V7 rendering regression gate after the observed multipart rendering regression where HTML-only multipart content could be withheld behind the historical placeholder instead of falling back to sanitized HTML.

## Evidence

Final local close-out evidence:

- Evidence archive: `osmap-v7-rendering-regression-closeout-evidence-20260620-013546Z.tar.gz`
- SHA-256: `6d4d1c3e7eac3584c72420d3900927f44aa34196d6a76a9c80f2ded456169337`
- Local close-out commit: `46941620bb000037809974da948b99d50a6cc4d7`

## Gates run

The close-out runner passed:

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make v7-check`
- `make security-check`
- `cargo audit`

## Notes

`main` is protected and requires pull request status checks. This PR carries the completed local close-out commit for CI verification and merge.
