### PR TITLE
add v8 mail workflow regression matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Keep developer entrypoints obvious and conservative so operators and
 # collaborating developers do not have to memorize cargo subcommands.
 
-.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check install-hooks run
+.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check install-hooks run
 
 build:
 	cargo build
@@ -49,6 +49,10 @@ v7-rendering-regression-check:
 
 v8-check:
 	sh maint/security/osmap-v8-stabilization-gate.sh
+	sh maint/security/osmap-v8-mail-workflow-gate.sh
+
+v8-mail-workflow-check:
+	sh maint/security/osmap-v8-mail-workflow-gate.sh
 
 install-hooks:
 	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v7-rendering-regression-gate.sh maint/security/test-osmap-v7-rendering-regression-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py

--- a/docs/V8_MAIL_WORKFLOW_MATRIX.md
+++ b/docs/V8_MAIL_WORKFLOW_MATRIX.md
@@ -1,0 +1,105 @@
+# V8 Mail Workflow Regression Matrix
+
+## Purpose
+
+V8 Slice 1 creates durable regression coverage for real-world mail workflows that OSMAP already needs to handle safely.
+
+This is not a feature expansion. The goal is to prevent already-supported mail reading behavior from regressing after the V7 rendering incident.
+
+## Scope
+
+The Slice 1 matrix covers these message shapes:
+
+- `text/plain`
+- `text/html`
+- `multipart/alternative`
+- `multipart/mixed`
+- nested multipart
+- attachment-heavy mail
+- malformed MIME
+
+The matrix verifies both internal rendering state and browser-facing labels.
+
+## Regression outcomes
+
+Each workflow must preserve the following outcomes:
+
+- body selection
+- body source labels
+- rendering mode labels
+- remote-content status
+- sanitized HTML notices
+- safe fallback behavior
+
+## Fixture inventory
+
+Fixtures live under:
+
+```text
+tests/fixtures/mail_workflows/
+```
+
+| Fixture | Message type | Required outcome |
+|---|---|---|
+| `text_plain.eml` | `text/plain` | Select plain body, render escaped text, label as `singlepart_plain_text` and `plain_text_preformatted` |
+| `text_html.eml` | `text/html` | Render sanitized HTML, remove active and remote-fetch surfaces, show remote-content and sanitized-HTML status |
+| `multipart_alternative.eml` | `multipart/alternative` | Render sanitized HTML by default, preserve plain-text preference behavior |
+| `multipart_mixed.eml` | `multipart/mixed` | Select plain body and surface attachment metadata |
+| `nested_multipart.eml` | nested multipart | Select nested HTML safely and surface inline Content-ID image metadata without inline rendering |
+| `attachment_heavy.eml` | attachment-heavy mail | Preserve body selection while surfacing multiple attachment metadata rows |
+| `malformed_mime.eml` | malformed MIME | Fail closed with a safe placeholder and without raw HTML rendering |
+
+## Test implementation
+
+The Rust integration test is:
+
+```text
+tests/v8_mail_workflow_matrix.rs
+```
+
+It validates:
+
+- fixture inventory
+- MIME body source classification
+- rendering mode classification
+- HTML-present status
+- attachment metadata count
+- message-view page Body Source label
+- message-view page Rendering Mode label
+- message-view page HTML Present label
+- remote-content page status
+- sanitized HTML notice
+- absence of raw active HTML markers
+- malformed MIME safe fallback behavior
+
+## Gate
+
+The executable gate is:
+
+```text
+maint/security/osmap-v8-mail-workflow-gate.sh
+```
+
+It performs fixture and documentation presence checks, then executes the real Rust test:
+
+```sh
+cargo test --test v8_mail_workflow_matrix
+```
+
+The aggregate V8 gate must run this Slice 1 gate through:
+
+```sh
+make v8-check
+```
+
+## Non-goals
+
+Slice 1 does not implement attachment filename safety coverage. That belongs to V8 Slice 2.
+
+Slice 1 does not implement mailbox state behavior coverage. That belongs to V8 Slice 3.
+
+Slice 1 does not implement session integrity coverage. That belongs to V8 Slice 4.
+
+Slice 1 does not implement resource exhaustion coverage. That belongs to V8 Slice 5.
+
+Slice 1 does not make CI enforcement final. That belongs to V8 Slice 6.

--- a/maint/security/osmap-v8-mail-workflow-gate.sh
+++ b/maint/security/osmap-v8-mail-workflow-gate.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V8_GATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_file() {
+	path=$1
+	if [ ! -s "$path" ]; then
+		echo "error: missing V8 mail workflow file: $path" >&2
+		exit 1
+	fi
+}
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V8 mail workflow requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+for path in \
+	docs/V8_MAIL_WORKFLOW_MATRIX.md \
+	tests/v8_mail_workflow_matrix.rs \
+	tests/fixtures/mail_workflows/MANIFEST.md \
+	tests/fixtures/mail_workflows/text_plain.eml \
+	tests/fixtures/mail_workflows/text_html.eml \
+	tests/fixtures/mail_workflows/multipart_alternative.eml \
+	tests/fixtures/mail_workflows/multipart_mixed.eml \
+	tests/fixtures/mail_workflows/nested_multipart.eml \
+	tests/fixtures/mail_workflows/attachment_heavy.eml \
+	tests/fixtures/mail_workflows/malformed_mime.eml
+	do
+	require_file "$path"
+done
+
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "body selection"
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "body source labels"
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "rendering mode labels"
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "remote-content status"
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "sanitized HTML notices"
+require_text docs/V8_MAIL_WORKFLOW_MATRIX.md "safe fallback behavior"
+require_text maint/security/osmap-v8-mail-workflow-gate.sh "cargo test --test v8_mail_workflow_matrix"
+require_text Makefile "osmap-v8-mail-workflow-gate.sh"
+
+echo "==> cargo test --test v8_mail_workflow_matrix"
+cargo test --test v8_mail_workflow_matrix
+
+echo "V8 mail workflow regression gate passed"

--- a/tests/fixtures/mail_workflows/MANIFEST.md
+++ b/tests/fixtures/mail_workflows/MANIFEST.md
@@ -1,0 +1,13 @@
+# V8 Mail Workflow Fixtures
+
+These fixtures support V8 Slice 1. They are intentionally small, synthetic, and focused on regression prevention.
+
+| Fixture | Message type | Regression objective |
+|---|---|---|
+| `text_plain.eml` | `text/plain` | Plain body selection, escaped browser rendering, plain-text labels |
+| `text_html.eml` | `text/html` | Sanitized HTML rendering, remote-content status, active-content stripping |
+| `multipart_alternative.eml` | `multipart/alternative` | Prefer-sanitized-HTML default and prefer-plain-text fallback |
+| `multipart_mixed.eml` | `multipart/mixed` | Plain body selection with attachment metadata surfaced |
+| `nested_multipart.eml` | nested multipart | Nested body selection and inline Content-ID metadata without inline rendering |
+| `attachment_heavy.eml` | attachment-heavy mail | Body selection preserved while multiple attachment metadata rows surface |
+| `malformed_mime.eml` | malformed MIME | Safe fallback without raw HTML rendering or panic |

--- a/tests/fixtures/mail_workflows/attachment_heavy.eml
+++ b/tests/fixtures/mail_workflows/attachment_heavy.eml
@@ -1,0 +1,35 @@
+Subject: V8 attachment heavy workflow
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 03:35:00 +0000
+Content-Type: multipart/mixed; boundary="v8-heavy"
+
+--v8-heavy
+Content-Type: text/plain; charset=utf-8
+
+Attachment-heavy workflow body remains selected before metadata.
+--v8-heavy
+Content-Type: text/plain; name="file-1.txt"
+Content-Disposition: attachment; filename="file-1.txt"
+
+first attachment
+--v8-heavy
+Content-Type: text/plain; name="file-2.txt"
+Content-Disposition: attachment; filename="file-2.txt"
+
+second attachment
+--v8-heavy
+Content-Type: text/plain; name="file-3.txt"
+Content-Disposition: attachment; filename="file-3.txt"
+
+third attachment
+--v8-heavy
+Content-Type: text/plain; name="file-4.txt"
+Content-Disposition: attachment; filename="file-4.txt"
+
+fourth attachment
+--v8-heavy
+Content-Type: text/plain; name="file-5.txt"
+Content-Disposition: attachment; filename="file-5.txt"
+
+fifth attachment
+--v8-heavy--

--- a/tests/fixtures/mail_workflows/malformed_mime.eml
+++ b/tests/fixtures/mail_workflows/malformed_mime.eml
@@ -1,0 +1,10 @@
+Subject: V8 malformed MIME workflow
+From: Malformed Sender <malformed@example.com>
+Date: Sat, 20 Jun 2026 03:36:00 +0000
+Content-Type: multipart/mixed; boundary="v8-missing"
+
+--wrong-boundary
+Content-Type: text/html; charset=utf-8
+
+<html><body><script>alert('must not render')</script><p>Malformed raw HTML body must not render.</p></body></html>
+--wrong-boundary--

--- a/tests/fixtures/mail_workflows/multipart_alternative.eml
+++ b/tests/fixtures/mail_workflows/multipart_alternative.eml
@@ -1,0 +1,14 @@
+Subject: V8 multipart alternative workflow
+From: Alternative Sender <alternative@example.com>
+Date: Sat, 20 Jun 2026 03:32:00 +0000
+Content-Type: multipart/alternative; boundary="v8-alt"
+
+--v8-alt
+Content-Type: text/plain; charset=utf-8
+
+Alternative plain body for compose and plain preference.
+--v8-alt
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Alternative HTML body visible.</p><script>evil()</script></body></html>
+--v8-alt--

--- a/tests/fixtures/mail_workflows/multipart_mixed.eml
+++ b/tests/fixtures/mail_workflows/multipart_mixed.eml
@@ -1,0 +1,16 @@
+Subject: V8 multipart mixed workflow
+From: Mixed Sender <mixed@example.com>
+Date: Sat, 20 Jun 2026 03:33:00 +0000
+Content-Type: multipart/mixed; boundary="v8-mixed"
+
+--v8-mixed
+Content-Type: text/plain; charset=utf-8
+
+Mixed workflow plain body with one attachment.
+--v8-mixed
+Content-Type: application/pdf; name="report.pdf"
+Content-Disposition: attachment; filename="report.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQKJXZ4LW1peGVkLXJlcG9ydAo=
+--v8-mixed--

--- a/tests/fixtures/mail_workflows/nested_multipart.eml
+++ b/tests/fixtures/mail_workflows/nested_multipart.eml
@@ -1,0 +1,29 @@
+Subject: V8 nested multipart workflow
+From: Nested Sender <nested@example.com>
+Date: Sat, 20 Jun 2026 03:34:00 +0000
+Content-Type: multipart/mixed; boundary="v8-outer"
+
+--v8-outer
+Content-Type: multipart/related; boundary="v8-related"
+
+--v8-related
+Content-Type: multipart/alternative; boundary="v8-nested-alt"
+
+--v8-nested-alt
+Content-Type: text/plain; charset=utf-8
+
+Nested plain body fallback.
+--v8-nested-alt
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Nested HTML workflow body visible.</p><img src="cid:v8-logo"></body></html>
+--v8-nested-alt--
+--v8-related
+Content-Type: image/png; name="logo.png"
+Content-Disposition: inline; filename="logo.png"
+Content-ID: <v8-logo>
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADElEQVR42mP8z8AARQAFAgH/qx9oAAAAAElFTkSuQmCC
+--v8-related--
+--v8-outer--

--- a/tests/fixtures/mail_workflows/text_html.eml
+++ b/tests/fixtures/mail_workflows/text_html.eml
@@ -1,0 +1,14 @@
+Subject: V8 HTML workflow
+From: Html Sender <html@example.com>
+Date: Sat, 20 Jun 2026 03:31:00 +0000
+Content-Type: text/html; charset=utf-8
+
+<!doctype html>
+<html>
+  <body>
+    <p>HTML workflow body <strong>visible</strong>.</p>
+    <img src="https://tracker.example/osmap-v8-pixel.png" alt="tracking pixel">
+    <script>alert('osmap-v8-regression')</script>
+    <a href="javascript:alert(1)">unsafe link</a>
+  </body>
+</html>

--- a/tests/fixtures/mail_workflows/text_plain.eml
+++ b/tests/fixtures/mail_workflows/text_plain.eml
@@ -1,0 +1,7 @@
+Subject: V8 plain text workflow
+From: Plain Sender <plain@example.com>
+Date: Sat, 20 Jun 2026 03:30:00 +0000
+Content-Type: text/plain; charset=utf-8
+
+Plain workflow body <must stay escaped> & visible.
+Second plain workflow line.

--- a/tests/v8_mail_workflow_matrix.rs
+++ b/tests/v8_mail_workflow_matrix.rs
@@ -1,0 +1,396 @@
+use std::path::{Path, PathBuf};
+
+use osmap::auth::{AuthenticationContext, AuthenticationPolicy, RequiredSecondFactor};
+use osmap::config::LogLevel;
+use osmap::http_ui::render_message_view_page;
+use osmap::logging::{EventCategory, LogEvent};
+use osmap::mailbox::{MailboxEntry, MessageView};
+use osmap::mime::{MimeAnalysisPolicy, MimeAnalyzer, MimeBodySource};
+use osmap::rendering::{
+    HtmlDisplayPreference, PlainTextMessageRenderer, RenderedMessageView, RenderingMode,
+    RenderingPolicy,
+};
+use osmap::session::{SessionRecord, ValidatedSession};
+
+#[derive(Debug, Clone, Copy)]
+struct WorkflowCase {
+    fixture_name: &'static str,
+    raw_message: &'static str,
+    expected_body_source: MimeBodySource,
+    expected_rendering_mode: RenderingMode,
+    expected_html_present: bool,
+    expected_attachment_count: usize,
+    expected_visible_text: &'static str,
+}
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn message_view_from_fixture(raw_message: &str) -> MessageView {
+    let normalized = raw_message.replace("\r\n", "\n");
+    let (header_block, body_text) = normalized
+        .split_once("\n\n")
+        .expect("fixture should contain a header/body separator");
+    MessageView {
+        mailbox_name: "INBOX".to_string(),
+        uid: 808,
+        flags: vec!["\\Seen".to_string()],
+        date_received: "2026-06-20 03:30:00 +0000".to_string(),
+        size_virtual: normalized.len() as u64,
+        header_block: header_block.to_string(),
+        body_text: body_text.to_string(),
+    }
+}
+
+fn test_context() -> AuthenticationContext {
+    AuthenticationContext::new(
+        AuthenticationPolicy::default(),
+        "req-v8-mail-workflow",
+        "127.0.0.1",
+        "Firefox/V8-Mail-Workflow",
+    )
+    .expect("authentication context should be valid")
+}
+
+fn validated_session_fixture() -> ValidatedSession {
+    ValidatedSession {
+        record: SessionRecord {
+            session_id: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            csrf_token: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+                .to_string(),
+            canonical_username: "alice@example.com".to_string(),
+            issued_at: 10,
+            expires_at: 100,
+            last_seen_at: 20,
+            revoked_at: None,
+            remote_addr: "127.0.0.1".to_string(),
+            user_agent: "Firefox/V8-Mail-Workflow".to_string(),
+            factor: RequiredSecondFactor::Totp,
+        },
+        audit_event: LogEvent::new(
+            LogLevel::Info,
+            EventCategory::Session,
+            "session_validated",
+            "browser session validated",
+        ),
+    }
+}
+
+fn render_fixture(
+    raw_message: &str,
+    html_display_preference: HtmlDisplayPreference,
+) -> RenderedMessageView {
+    let renderer = PlainTextMessageRenderer::new(RenderingPolicy {
+        html_display_preference,
+        ..RenderingPolicy::default()
+    });
+    renderer
+        .render_for_validated_session(
+            &test_context(),
+            &validated_session_fixture(),
+            &message_view_from_fixture(raw_message),
+        )
+        .expect("workflow fixture should render safely")
+        .rendered
+}
+
+fn message_page_html(rendered: &RenderedMessageView) -> String {
+    let mailboxes = vec![
+        MailboxEntry {
+            name: "INBOX".to_string(),
+        },
+        MailboxEntry {
+            name: "Archive".to_string(),
+        },
+        MailboxEntry {
+            name: "Trash".to_string(),
+        },
+    ];
+    render_message_view_page(
+        "alice@example.com",
+        "csrf-v8-mail-workflow",
+        rendered,
+        Some("Archive"),
+        &mailboxes,
+    )
+    .to_string()
+}
+
+fn assert_body_source_and_rendering_labels(rendered: &RenderedMessageView, page_html: &str) {
+    let expected_body_source = format!(
+        "<dt>Body Source</dt><dd>{}</dd>",
+        rendered.body_source.as_str()
+    );
+    let expected_rendering_mode = format!(
+        "<dt>Rendering Mode</dt><dd>{}</dd>",
+        rendered.rendering_mode.as_str()
+    );
+    let expected_html_present = format!(
+        "<dt>HTML Present</dt><dd>{}</dd>",
+        if rendered.contains_html_body {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
+    assert!(
+        page_html.contains(&expected_body_source),
+        "message view page did not expose body source label {expected_body_source}"
+    );
+    assert!(
+        page_html.contains(&expected_rendering_mode),
+        "message view page did not expose rendering mode label {expected_rendering_mode}"
+    );
+    assert!(
+        page_html.contains(&expected_html_present),
+        "message view page did not expose HTML-present label {expected_html_present}"
+    );
+}
+
+fn assert_no_raw_active_html(rendered: &RenderedMessageView) {
+    let body_html = rendered.body_html.as_str();
+    for forbidden in [
+        "<script",
+        "</script>",
+        "javascript:",
+        "onerror",
+        "tracker.example",
+        "alert('must not render')",
+        "Malformed raw HTML body must not render.",
+    ] {
+        assert!(
+            !body_html.contains(forbidden),
+            "rendered body retained forbidden active or unsafe HTML marker {forbidden}: {body_html}"
+        );
+    }
+}
+
+#[test]
+fn v8_mail_workflow_fixture_inventory_is_complete() {
+    for relative in [
+        "tests/fixtures/mail_workflows/MANIFEST.md",
+        "tests/fixtures/mail_workflows/text_plain.eml",
+        "tests/fixtures/mail_workflows/text_html.eml",
+        "tests/fixtures/mail_workflows/multipart_alternative.eml",
+        "tests/fixtures/mail_workflows/multipart_mixed.eml",
+        "tests/fixtures/mail_workflows/nested_multipart.eml",
+        "tests/fixtures/mail_workflows/attachment_heavy.eml",
+        "tests/fixtures/mail_workflows/malformed_mime.eml",
+        "docs/V8_MAIL_WORKFLOW_MATRIX.md",
+        "maint/security/osmap-v8-mail-workflow-gate.sh",
+    ] {
+        assert!(repo_path(relative).is_file(), "missing {relative}");
+    }
+}
+
+#[test]
+fn v8_mail_workflow_matrix_verifies_body_selection_and_labels() {
+    let cases = [
+        WorkflowCase {
+            fixture_name: "text_plain",
+            raw_message: include_str!("fixtures/mail_workflows/text_plain.eml"),
+            expected_body_source: MimeBodySource::SinglePartPlainText,
+            expected_rendering_mode: RenderingMode::PlainTextPreformatted,
+            expected_html_present: false,
+            expected_attachment_count: 0,
+            expected_visible_text: "Plain workflow body",
+        },
+        WorkflowCase {
+            fixture_name: "text_html",
+            raw_message: include_str!("fixtures/mail_workflows/text_html.eml"),
+            expected_body_source: MimeBodySource::HtmlSanitized,
+            expected_rendering_mode: RenderingMode::SanitizedHtml,
+            expected_html_present: true,
+            expected_attachment_count: 0,
+            expected_visible_text: "HTML workflow body",
+        },
+        WorkflowCase {
+            fixture_name: "multipart_alternative",
+            raw_message: include_str!("fixtures/mail_workflows/multipart_alternative.eml"),
+            expected_body_source: MimeBodySource::MultipartHtmlSanitized,
+            expected_rendering_mode: RenderingMode::SanitizedHtml,
+            expected_html_present: true,
+            expected_attachment_count: 0,
+            expected_visible_text: "Alternative HTML body visible.",
+        },
+        WorkflowCase {
+            fixture_name: "multipart_mixed",
+            raw_message: include_str!("fixtures/mail_workflows/multipart_mixed.eml"),
+            expected_body_source: MimeBodySource::MultipartPlainTextPart,
+            expected_rendering_mode: RenderingMode::PlainTextPreformatted,
+            expected_html_present: false,
+            expected_attachment_count: 1,
+            expected_visible_text: "Mixed workflow plain body",
+        },
+        WorkflowCase {
+            fixture_name: "nested_multipart",
+            raw_message: include_str!("fixtures/mail_workflows/nested_multipart.eml"),
+            expected_body_source: MimeBodySource::MultipartHtmlSanitized,
+            expected_rendering_mode: RenderingMode::SanitizedHtml,
+            expected_html_present: true,
+            expected_attachment_count: 1,
+            expected_visible_text: "Nested HTML workflow body visible.",
+        },
+        WorkflowCase {
+            fixture_name: "attachment_heavy",
+            raw_message: include_str!("fixtures/mail_workflows/attachment_heavy.eml"),
+            expected_body_source: MimeBodySource::MultipartPlainTextPart,
+            expected_rendering_mode: RenderingMode::PlainTextPreformatted,
+            expected_html_present: false,
+            expected_attachment_count: 5,
+            expected_visible_text: "Attachment-heavy workflow body remains selected",
+        },
+    ];
+
+    for case in cases {
+        let rendered = render_fixture(case.raw_message, HtmlDisplayPreference::PreferSanitizedHtml);
+        assert_eq!(
+            rendered.body_source, case.expected_body_source,
+            "{} body source changed",
+            case.fixture_name
+        );
+        assert_eq!(
+            rendered.rendering_mode, case.expected_rendering_mode,
+            "{} rendering mode changed",
+            case.fixture_name
+        );
+        assert_eq!(
+            rendered.contains_html_body, case.expected_html_present,
+            "{} HTML-present status changed",
+            case.fixture_name
+        );
+        assert_eq!(
+            rendered.attachments.len(),
+            case.expected_attachment_count,
+            "{} attachment metadata count changed",
+            case.fixture_name
+        );
+        assert!(
+            rendered
+                .body_html
+                .as_str()
+                .contains(case.expected_visible_text),
+            "{} selected body text was not rendered: {}",
+            case.fixture_name,
+            rendered.body_html.as_str()
+        );
+
+        let page_html = message_page_html(&rendered);
+        assert_body_source_and_rendering_labels(&rendered, &page_html);
+
+        if case.expected_html_present {
+            assert!(
+                page_html.contains("remote content blocked"),
+                "{} page did not surface remote-content status",
+                case.fixture_name
+            );
+        } else {
+            assert!(
+                page_html.contains("safe text render"),
+                "{} page did not surface safe text status",
+                case.fixture_name
+            );
+        }
+
+        if case.expected_rendering_mode == RenderingMode::SanitizedHtml {
+            assert!(
+                page_html.contains("Sanitized HTML:"),
+                "{} page did not surface sanitized HTML notice",
+                case.fixture_name
+            );
+        }
+
+        assert_no_raw_active_html(&rendered);
+    }
+}
+
+#[test]
+fn v8_mail_workflow_matrix_preserves_prefer_plain_text_behavior() {
+    let rendered = render_fixture(
+        include_str!("fixtures/mail_workflows/multipart_alternative.eml"),
+        HtmlDisplayPreference::PreferPlainText,
+    );
+    assert_eq!(rendered.body_source, MimeBodySource::MultipartPlainTextPart);
+    assert_eq!(
+        rendered.rendering_mode,
+        RenderingMode::PlainTextPreformatted
+    );
+    assert!(rendered.contains_html_body);
+    assert!(rendered
+        .body_html
+        .as_str()
+        .contains("Alternative plain body for compose and plain preference."));
+    assert!(!rendered
+        .body_html
+        .as_str()
+        .contains("Alternative HTML body visible."));
+
+    let page_html = message_page_html(&rendered);
+    assert_body_source_and_rendering_labels(&rendered, &page_html);
+    assert!(page_html.contains("remote content blocked"));
+    assert!(!page_html.contains("Sanitized HTML:"));
+}
+
+#[test]
+fn v8_mail_workflow_matrix_surfaces_inline_content_without_rendering_it_inline() {
+    let rendered = render_fixture(
+        include_str!("fixtures/mail_workflows/nested_multipart.eml"),
+        HtmlDisplayPreference::PreferSanitizedHtml,
+    );
+    assert_eq!(rendered.attachments.len(), 1);
+    assert_eq!(
+        rendered.attachments[0].filename.as_deref(),
+        Some("logo.png")
+    );
+    assert_eq!(
+        rendered.attachments[0].content_id.as_deref(),
+        Some("v8-logo")
+    );
+    assert_eq!(rendered.attachments[0].disposition.as_str(), "inline");
+
+    let page_html = message_page_html(&rendered);
+    assert!(page_html.contains("Remote content blocked by policy:"));
+    assert!(page_html.contains("Content-ID <strong>cid:v8-logo</strong>"));
+    assert!(page_html.contains("Download"));
+    assert_no_raw_active_html(&rendered);
+}
+
+#[test]
+fn v8_mail_workflow_matrix_malformed_mime_falls_back_safely() {
+    let analyzer = MimeAnalyzer::new(MimeAnalysisPolicy::default());
+    let analysis = analyzer
+        .analyze_message(&message_view_from_fixture(include_str!(
+            "fixtures/mail_workflows/malformed_mime.eml"
+        )))
+        .expect("malformed MIME should fail closed without panic");
+    assert_eq!(
+        analysis.body_source,
+        MimeBodySource::MultipartStructureWithheld
+    );
+    assert!(analysis.attachments.is_empty());
+
+    let rendered = render_fixture(
+        include_str!("fixtures/mail_workflows/malformed_mime.eml"),
+        HtmlDisplayPreference::PreferSanitizedHtml,
+    );
+    assert_eq!(
+        rendered.body_source,
+        MimeBodySource::MultipartStructureWithheld
+    );
+    assert_eq!(
+        rendered.rendering_mode,
+        RenderingMode::PlainTextPreformatted
+    );
+    assert!(rendered
+        .body_html
+        .as_str()
+        .contains("Multipart structure detected, but no safe plain-text preview is available."));
+    assert_no_raw_active_html(&rendered);
+
+    let page_html = message_page_html(&rendered);
+    assert_body_source_and_rendering_labels(&rendered, &page_html);
+    assert!(page_html.contains("safe text render"));
+}


### PR DESCRIPTION
## Summary

Adds the V8 Slice 1 mail workflow regression matrix.

This slice protects existing mail reading behavior after the V7 rendering regression incident. It does not add new end-user features.

## Changes

- Adds synthetic mail workflow fixtures
- Adds tests/v8_mail_workflow_matrix.rs
- Adds docs/V8_MAIL_WORKFLOW_MATRIX.md
- Adds maint/security/osmap-v8-mail-workflow-gate.sh
- Wires the mail workflow gate into make v8-check
- Adds make v8-mail-workflow-check

## Matrix coverage

- text/plain
- text/html
- multipart/alternative
- multipart/mixed
- nested multipart
- attachment-heavy mail
- malformed MIME

## Validation

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make v7-check
- make v8-check
- make security-check

## Evidence

- /home/foo/osmap-v8-evidence/osmap-v8-slice1-mail-workflow-matrix-repair-v2-20260620-040926Z
- /home/foo/osmap-v8-evidence/osmap-v8-slice1-mail-workflow-matrix-repair-v2-20260620-040926Z.tar.gz
- /home/foo/osmap-v8-evidence/osmap-v8-slice1-mail-workflow-matrix-repair-v2-20260620-040926Z.tar.gz.sha256