### PR TITLE
add v8 attachment safety regression matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Keep developer entrypoints obvious and conservative so operators and
 # collaborating developers do not have to memorize cargo subcommands.
 
-.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check install-hooks run
+.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check v8-attachment-safety-check install-hooks run
 
 build:
 	cargo build
@@ -50,9 +50,13 @@ v7-rendering-regression-check:
 v8-check:
 	sh maint/security/osmap-v8-stabilization-gate.sh
 	sh maint/security/osmap-v8-mail-workflow-gate.sh
+	sh maint/security/osmap-v8-attachment-safety-gate.sh
 
 v8-mail-workflow-check:
 	sh maint/security/osmap-v8-mail-workflow-gate.sh
+
+v8-attachment-safety-check:
+	sh maint/security/osmap-v8-attachment-safety-gate.sh
 
 install-hooks:
 	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v7-rendering-regression-gate.sh maint/security/test-osmap-v7-rendering-regression-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py

--- a/docs/V8_ATTACHMENT_SAFETY_MATRIX.md
+++ b/docs/V8_ATTACHMENT_SAFETY_MATRIX.md
@@ -1,0 +1,99 @@
+# V8 Attachment Safety Regression Matrix
+
+## Purpose
+
+V8 Slice 2 creates durable regression coverage for attachment download safety.
+
+This is not a feature expansion. The goal is to prevent already-supported attachment behavior from regressing after the V7 testing discipline incident.
+
+## Scope
+
+The Slice 2 matrix covers:
+
+- safe media type preservation
+- browser-executable media type fallback to `application/octet-stream`
+- filename sanitization
+- generated fallback filenames for untrusted path-shaped metadata
+- base64 decoding
+- quoted-printable decoding
+- unsupported transfer encoding fail-closed behavior
+- decoded attachment byte limits
+- invalid and unsurfaced part path rejection
+- forced-download HTTP headers
+- attachment audit redaction
+
+## Fixture inventory
+
+Fixtures live under:
+
+```text
+tests/fixtures/attachments/
+```
+
+| Fixture | Required outcome |
+|---|---|
+| `safe_pdf_base64.eml` | Decode base64 PDF bytes, preserve `report.pdf`, preserve `application/pdf`, force download headers |
+| `quoted_printable_text.eml` | Decode quoted-printable bytes, preserve `notes.txt`, preserve `text/plain`, force download headers |
+| `suspicious_html_attachment.eml` | Sanitize hostile filename metadata and force `text/html` to `application/octet-stream` |
+| `svg_active_attachment.eml` | Force `image/svg+xml` to `application/octet-stream` |
+| `generated_filename_fallback.eml` | Replace path-shaped filename metadata with generated fallback filename |
+| `unsupported_encoding.eml` | Deny unsupported transfer encoding with stable public and audit reasons |
+
+## Test implementation
+
+The Rust integration test is:
+
+```text
+tests/v8_attachment_safety_matrix.rs
+```
+
+It validates:
+
+- fixture inventory
+- filename safety
+- content type normalization
+- decoded attachment bytes
+- mailbox and UID preservation
+- surfaced part path preservation
+- forced-download response headers
+- invalid part path rejection
+- unsurfaced part path rejection
+- unsupported encoding fail-closed behavior
+- decoded size fail-closed behavior
+- audit field redaction
+
+## Gate
+
+The executable gate is:
+
+```text
+maint/security/osmap-v8-attachment-safety-gate.sh
+```
+
+It performs fixture and documentation presence checks, then executes the Rust test:
+
+```sh
+cargo test --test v8_attachment_safety_matrix
+```
+
+The aggregate V8 gate must run this Slice 2 gate through:
+
+```sh
+make v8-check
+```
+
+A dedicated convenience target is also provided:
+
+```sh
+make v8-attachment-safety-check
+```
+
+## Non-goals
+
+Slice 2 does not implement mailbox listing, search, sort, move, or archive coverage. That belongs to V8 Slice 3.
+
+Slice 2 does not implement session integrity coverage. That belongs to V8 Slice 4.
+
+Slice 2 does not implement resource exhaustion and robustness coverage. That belongs to V8 Slice 5.
+
+Slice 2 does not make final CI enforcement changes. That belongs to V8 Slice 6.

--- a/maint/security/osmap-v8-attachment-safety-gate.sh
+++ b/maint/security/osmap-v8-attachment-safety-gate.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V8_GATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_file() {
+	path=$1
+	if [ ! -s "$path" ]; then
+		echo "error: missing V8 attachment safety file: $path" >&2
+		exit 1
+	fi
+}
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V8 attachment safety requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+for path in \
+	docs/V8_ATTACHMENT_SAFETY_MATRIX.md \
+	tests/v8_attachment_safety_matrix.rs \
+	tests/fixtures/attachments/MANIFEST.md \
+	tests/fixtures/attachments/safe_pdf_base64.eml \
+	tests/fixtures/attachments/quoted_printable_text.eml \
+	tests/fixtures/attachments/suspicious_html_attachment.eml \
+	tests/fixtures/attachments/svg_active_attachment.eml \
+	tests/fixtures/attachments/generated_filename_fallback.eml \
+	tests/fixtures/attachments/unsupported_encoding.eml
+	do
+	require_file "$path"
+done
+
+require_text docs/V8_ATTACHMENT_SAFETY_MATRIX.md "forced-download HTTP headers"
+require_text docs/V8_ATTACHMENT_SAFETY_MATRIX.md "filename sanitization"
+require_text docs/V8_ATTACHMENT_SAFETY_MATRIX.md "application/octet-stream"
+require_text docs/V8_ATTACHMENT_SAFETY_MATRIX.md "unsupported transfer encoding fail-closed behavior"
+require_text tests/v8_attachment_safety_matrix.rs "X-Content-Type-Options"
+require_text tests/v8_attachment_safety_matrix.rs "attachment_download_response"
+require_text tests/v8_attachment_safety_matrix.rs "TemporarilyUnavailable"
+require_text maint/security/osmap-v8-attachment-safety-gate.sh "cargo test --test v8_attachment_safety_matrix"
+require_text Makefile "osmap-v8-attachment-safety-gate.sh"
+
+echo "==> cargo test --test v8_attachment_safety_matrix"
+cargo test --test v8_attachment_safety_matrix
+
+echo "V8 attachment safety regression gate passed"

--- a/tests/fixtures/attachments/MANIFEST.md
+++ b/tests/fixtures/attachments/MANIFEST.md
@@ -1,0 +1,12 @@
+# V8 Attachment Safety Fixtures
+
+These fixtures support V8 Slice 2. They are synthetic and intentionally small.
+
+| Fixture | Regression objective |
+|---|---|
+| `safe_pdf_base64.eml` | Decode base64 attachment, preserve safe filename, preserve safe media type, force download headers |
+| `quoted_printable_text.eml` | Decode quoted-printable attachment bytes without widening response headers |
+| `suspicious_html_attachment.eml` | Preserve payload as download-only data while forcing browser-executable HTML to `application/octet-stream` |
+| `svg_active_attachment.eml` | Force browser-executable SVG to `application/octet-stream` and keep forced-download headers |
+| `generated_filename_fallback.eml` | Reject path-trusted filename metadata and generate a safe fallback filename |
+| `unsupported_encoding.eml` | Fail closed for unsupported transfer encoding with public and audit reasons |

--- a/tests/fixtures/attachments/generated_filename_fallback.eml
+++ b/tests/fixtures/attachments/generated_filename_fallback.eml
@@ -1,0 +1,15 @@
+Subject: V8 generated filename fallback
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:34:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-fallback"
+
+--v8-attach-fallback
+Content-Type: text/plain; charset=utf-8
+
+Generated filename fallback workflow.
+--v8-attach-fallback
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="../../...___"
+
+payload
+--v8-attach-fallback--

--- a/tests/fixtures/attachments/quoted_printable_text.eml
+++ b/tests/fixtures/attachments/quoted_printable_text.eml
@@ -1,0 +1,16 @@
+Subject: V8 quoted printable attachment
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:31:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-qp"
+
+--v8-attach-qp
+Content-Type: text/plain; charset=utf-8
+
+Quoted printable attachment workflow.
+--v8-attach-qp
+Content-Type: text/plain
+Content-Disposition: attachment; filename="notes.txt"
+Content-Transfer-Encoding: quoted-printable
+
+hello=20quoted=2Dprintable=0A
+--v8-attach-qp--

--- a/tests/fixtures/attachments/safe_pdf_base64.eml
+++ b/tests/fixtures/attachments/safe_pdf_base64.eml
@@ -1,0 +1,16 @@
+Subject: V8 safe PDF attachment
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:30:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-safe-pdf"
+
+--v8-attach-safe-pdf
+Content-Type: text/plain; charset=utf-8
+
+Safe PDF attachment workflow.
+--v8-attach-safe-pdf
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="report.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi12OAo=
+--v8-attach-safe-pdf--

--- a/tests/fixtures/attachments/suspicious_html_attachment.eml
+++ b/tests/fixtures/attachments/suspicious_html_attachment.eml
@@ -1,0 +1,15 @@
+Subject: V8 suspicious HTML attachment
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:32:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-html"
+
+--v8-attach-html
+Content-Type: text/plain; charset=utf-8
+
+Suspicious HTML attachment workflow.
+--v8-attach-html
+Content-Type: text/html
+Content-Disposition: attachment; filename="../../invoice<script>.html"
+
+<html><body><script>alert('download-only')</script><p>download me</p></body></html>
+--v8-attach-html--

--- a/tests/fixtures/attachments/svg_active_attachment.eml
+++ b/tests/fixtures/attachments/svg_active_attachment.eml
@@ -1,0 +1,15 @@
+Subject: V8 active SVG attachment
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:33:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-svg"
+
+--v8-attach-svg
+Content-Type: text/plain; charset=utf-8
+
+SVG attachment workflow.
+--v8-attach-svg
+Content-Type: image/svg+xml
+Content-Disposition: attachment; filename="chart.svg"
+
+<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>
+--v8-attach-svg--

--- a/tests/fixtures/attachments/unsupported_encoding.eml
+++ b/tests/fixtures/attachments/unsupported_encoding.eml
@@ -1,0 +1,16 @@
+Subject: V8 unsupported attachment encoding
+From: Attachment Sender <attachments@example.com>
+Date: Sat, 20 Jun 2026 04:35:00 +0000
+Content-Type: multipart/mixed; boundary="v8-attach-unsupported"
+
+--v8-attach-unsupported
+Content-Type: text/plain; charset=utf-8
+
+Unsupported encoding workflow.
+--v8-attach-unsupported
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="encoded.bin"
+Content-Transfer-Encoding: x-rot13
+
+uryyb
+--v8-attach-unsupported--

--- a/tests/v8_attachment_safety_matrix.rs
+++ b/tests/v8_attachment_safety_matrix.rs
@@ -1,0 +1,345 @@
+use std::path::{Path, PathBuf};
+
+use osmap::attachment::{
+    AttachmentDownloadDecision, AttachmentDownloadPolicy, AttachmentDownloadPublicFailureReason,
+    AttachmentDownloadService, DownloadedAttachment,
+};
+use osmap::auth::{AuthenticationContext, AuthenticationPolicy, RequiredSecondFactor};
+use osmap::config::LogLevel;
+use osmap::http::HttpResponse;
+use osmap::http_support::attachment_download_response;
+use osmap::logging::{EventCategory, LogEvent};
+use osmap::mailbox::MessageView;
+use osmap::session::{SessionRecord, ValidatedSession};
+
+#[derive(Debug, Clone, Copy)]
+struct AttachmentCase {
+    fixture_name: &'static str,
+    raw_message: &'static str,
+    expected_filename: &'static str,
+    expected_content_type: &'static str,
+    expected_body_marker: &'static [u8],
+}
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn message_view_from_fixture(raw_message: &str) -> MessageView {
+    let normalized = raw_message.replace("\r\n", "\n");
+    let (header_block, body_text) = normalized
+        .split_once("\n\n")
+        .expect("fixture should contain a header/body separator");
+    MessageView {
+        mailbox_name: "INBOX".to_string(),
+        uid: 808,
+        flags: vec!["\\Seen".to_string()],
+        date_received: "2026-06-20 04:30:00 +0000".to_string(),
+        size_virtual: normalized.len() as u64,
+        header_block: header_block.to_string(),
+        body_text: body_text.to_string(),
+    }
+}
+
+fn test_context() -> AuthenticationContext {
+    AuthenticationContext::new(
+        AuthenticationPolicy::default(),
+        "req-v8-attachment-safety",
+        "127.0.0.1",
+        "Firefox/V8-Attachment-Safety",
+    )
+    .expect("authentication context should be valid")
+}
+
+fn validated_session_fixture() -> ValidatedSession {
+    ValidatedSession {
+        record: SessionRecord {
+            session_id: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+            csrf_token: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+                .to_string(),
+            canonical_username: "alice@example.com".to_string(),
+            issued_at: 10,
+            expires_at: 100,
+            last_seen_at: 20,
+            revoked_at: None,
+            remote_addr: "127.0.0.1".to_string(),
+            user_agent: "Firefox/V8-Attachment-Safety".to_string(),
+            factor: RequiredSecondFactor::Totp,
+        },
+        audit_event: LogEvent::new(
+            LogLevel::Info,
+            EventCategory::Session,
+            "session_validated",
+            "browser session validated",
+        ),
+    }
+}
+
+fn download_attachment_with_policy(
+    raw_message: &str,
+    part_path: &str,
+    policy: AttachmentDownloadPolicy,
+) -> (AttachmentDownloadDecision, LogEvent) {
+    let outcome = AttachmentDownloadService::new(policy).download_for_validated_session(
+        &test_context(),
+        &validated_session_fixture(),
+        &message_view_from_fixture(raw_message),
+        part_path,
+    );
+    (outcome.decision, outcome.audit_event)
+}
+
+fn downloaded_attachment(raw_message: &str) -> (DownloadedAttachment, LogEvent) {
+    let (decision, audit_event) =
+        download_attachment_with_policy(raw_message, "1.2", AttachmentDownloadPolicy::default());
+    match decision {
+        AttachmentDownloadDecision::Downloaded { attachment, .. } => (attachment, audit_event),
+        other => panic!("expected downloaded attachment, got {other:?}"),
+    }
+}
+
+fn response_header<'a>(response: &'a HttpResponse, name: &str) -> Option<&'a str> {
+    response
+        .headers
+        .iter()
+        .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn event_field<'a>(event: &'a LogEvent, key: &str) -> Option<&'a str> {
+    event
+        .fields
+        .iter()
+        .find(|field| field.key == key)
+        .map(|field| field.value.as_str())
+}
+
+fn assert_forced_download_response(attachment: &DownloadedAttachment) {
+    let response = attachment_download_response(attachment);
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body, attachment.body);
+
+    assert_eq!(
+        response_header(&response, "Content-Type"),
+        Some(attachment.content_type.as_str())
+    );
+    assert_eq!(
+        response_header(&response, "Content-Disposition"),
+        Some(format!("attachment; filename=\"{}\"", attachment.filename).as_str())
+    );
+    assert_eq!(
+        response_header(&response, "Cache-Control"),
+        Some("no-store")
+    );
+    assert_eq!(
+        response_header(&response, "Cross-Origin-Resource-Policy"),
+        Some("same-origin")
+    );
+    assert_eq!(
+        response_header(&response, "Referrer-Policy"),
+        Some("no-referrer")
+    );
+    assert_eq!(
+        response_header(&response, "X-Content-Type-Options"),
+        Some("nosniff")
+    );
+    assert_eq!(response_header(&response, "X-Frame-Options"), Some("DENY"));
+}
+
+#[test]
+fn v8_attachment_safety_fixture_inventory_is_complete() {
+    for relative in [
+        "tests/fixtures/attachments/MANIFEST.md",
+        "tests/fixtures/attachments/safe_pdf_base64.eml",
+        "tests/fixtures/attachments/quoted_printable_text.eml",
+        "tests/fixtures/attachments/suspicious_html_attachment.eml",
+        "tests/fixtures/attachments/svg_active_attachment.eml",
+        "tests/fixtures/attachments/generated_filename_fallback.eml",
+        "tests/fixtures/attachments/unsupported_encoding.eml",
+        "docs/V8_ATTACHMENT_SAFETY_MATRIX.md",
+        "maint/security/osmap-v8-attachment-safety-gate.sh",
+    ] {
+        assert!(repo_path(relative).is_file(), "missing {relative}");
+    }
+}
+
+#[test]
+fn v8_attachment_safety_matrix_enforces_download_metadata_and_headers() {
+    let cases = [
+        AttachmentCase {
+            fixture_name: "safe_pdf_base64",
+            raw_message: include_str!("fixtures/attachments/safe_pdf_base64.eml"),
+            expected_filename: "report.pdf",
+            expected_content_type: "application/pdf",
+            expected_body_marker: b"%PDF-v8\n",
+        },
+        AttachmentCase {
+            fixture_name: "quoted_printable_text",
+            raw_message: include_str!("fixtures/attachments/quoted_printable_text.eml"),
+            expected_filename: "notes.txt",
+            expected_content_type: "text/plain",
+            expected_body_marker: b"hello quoted-printable\n",
+        },
+        AttachmentCase {
+            fixture_name: "suspicious_html_attachment",
+            raw_message: include_str!("fixtures/attachments/suspicious_html_attachment.eml"),
+            expected_filename: "invoice_script_.html",
+            expected_content_type: "application/octet-stream",
+            expected_body_marker: b"download me",
+        },
+        AttachmentCase {
+            fixture_name: "svg_active_attachment",
+            raw_message: include_str!("fixtures/attachments/svg_active_attachment.eml"),
+            expected_filename: "chart.svg",
+            expected_content_type: "application/octet-stream",
+            expected_body_marker: b"<svg",
+        },
+        AttachmentCase {
+            fixture_name: "generated_filename_fallback",
+            raw_message: include_str!("fixtures/attachments/generated_filename_fallback.eml"),
+            expected_filename: "attachment-808-1-2.bin",
+            expected_content_type: "application/octet-stream",
+            expected_body_marker: b"payload",
+        },
+    ];
+
+    for case in cases {
+        let (attachment, audit_event) = downloaded_attachment(case.raw_message);
+        assert_eq!(
+            attachment.filename, case.expected_filename,
+            "{} filename changed",
+            case.fixture_name
+        );
+        assert_eq!(
+            attachment.content_type, case.expected_content_type,
+            "{} content type changed",
+            case.fixture_name
+        );
+        assert!(
+            attachment
+                .body
+                .windows(case.expected_body_marker.len())
+                .any(|window| window == case.expected_body_marker),
+            "{} body marker was not found in downloaded attachment",
+            case.fixture_name
+        );
+        assert_eq!(attachment.mailbox_name, "INBOX");
+        assert_eq!(attachment.uid, 808);
+        assert_eq!(attachment.part_path, "1.2");
+
+        assert_forced_download_response(&attachment);
+
+        assert_eq!(audit_event.action, "attachment_downloaded");
+        assert_eq!(
+            event_field(&audit_event, "canonical_username"),
+            Some("alice@example.com")
+        );
+        assert_eq!(event_field(&audit_event, "mailbox_name"), Some("INBOX"));
+        assert_eq!(event_field(&audit_event, "uid"), Some("808"));
+        assert_eq!(event_field(&audit_event, "part_path"), Some("1.2"));
+        assert_eq!(
+            event_field(&audit_event, "content_type"),
+            Some(attachment.content_type.as_str())
+        );
+        assert_eq!(event_field(&audit_event, "filename_present"), Some("true"));
+        assert!(event_field(&audit_event, "session_ref").is_some());
+        assert!(
+            event_field(&audit_event, "session_id").is_none(),
+            "raw session id must not be present in attachment audit fields"
+        );
+    }
+}
+
+#[test]
+fn v8_attachment_safety_matrix_rejects_unsurfaced_and_invalid_part_paths() {
+    for part_path in ["", "1", "2.1", "1.02", "1..2", ".1.2", "1.2.", "../bad"] {
+        let (decision, audit_event) = download_attachment_with_policy(
+            include_str!("fixtures/attachments/safe_pdf_base64.eml"),
+            part_path,
+            AttachmentDownloadPolicy::default(),
+        );
+
+        assert_eq!(
+            decision,
+            AttachmentDownloadDecision::Denied {
+                public_reason: AttachmentDownloadPublicFailureReason::InvalidRequest
+            },
+            "part path {part_path:?} should be rejected"
+        );
+        assert_eq!(audit_event.action, "attachment_download_failed");
+        assert_eq!(
+            event_field(&audit_event, "public_reason"),
+            Some("invalid_request")
+        );
+        assert_eq!(
+            event_field(&audit_event, "audit_reason"),
+            Some("invalid_request")
+        );
+        assert_eq!(event_field(&audit_event, "part_path"), Some(part_path));
+    }
+
+    let (decision, audit_event) = download_attachment_with_policy(
+        include_str!("fixtures/attachments/safe_pdf_base64.eml"),
+        "1.9",
+        AttachmentDownloadPolicy::default(),
+    );
+    assert_eq!(
+        decision,
+        AttachmentDownloadDecision::Denied {
+            public_reason: AttachmentDownloadPublicFailureReason::NotFound
+        }
+    );
+    assert_eq!(
+        event_field(&audit_event, "public_reason"),
+        Some("not_found")
+    );
+    assert_eq!(event_field(&audit_event, "audit_reason"), Some("not_found"));
+}
+
+#[test]
+fn v8_attachment_safety_matrix_fails_closed_for_unsafe_decoding() {
+    let (unsupported_decision, unsupported_event) = download_attachment_with_policy(
+        include_str!("fixtures/attachments/unsupported_encoding.eml"),
+        "1.2",
+        AttachmentDownloadPolicy::default(),
+    );
+    assert_eq!(
+        unsupported_decision,
+        AttachmentDownloadDecision::Denied {
+            public_reason: AttachmentDownloadPublicFailureReason::TemporarilyUnavailable
+        }
+    );
+    assert_eq!(
+        event_field(&unsupported_event, "public_reason"),
+        Some("temporarily_unavailable")
+    );
+    assert_eq!(
+        event_field(&unsupported_event, "audit_reason"),
+        Some("unsupported_encoding")
+    );
+
+    let restrictive_policy = AttachmentDownloadPolicy {
+        download_max_bytes: 3,
+        ..AttachmentDownloadPolicy::default()
+    };
+    let (oversized_decision, oversized_event) = download_attachment_with_policy(
+        include_str!("fixtures/attachments/safe_pdf_base64.eml"),
+        "1.2",
+        restrictive_policy,
+    );
+    assert_eq!(
+        oversized_decision,
+        AttachmentDownloadDecision::Denied {
+            public_reason: AttachmentDownloadPublicFailureReason::TemporarilyUnavailable
+        }
+    );
+    assert_eq!(
+        event_field(&oversized_event, "public_reason"),
+        Some("temporarily_unavailable")
+    );
+    assert_eq!(
+        event_field(&oversized_event, "audit_reason"),
+        Some("output_rejected")
+    );
+}


### PR DESCRIPTION
## Summary

Adds the V8 Slice 2 attachment safety regression matrix.

This slice protects existing attachment download behavior. It does not add new end-user features.

## Changes

- Adds synthetic attachment fixtures
- Adds tests/v8_attachment_safety_matrix.rs
- Adds docs/V8_ATTACHMENT_SAFETY_MATRIX.md
- Adds maint/security/osmap-v8-attachment-safety-gate.sh
- Wires the attachment safety gate into make v8-check
- Adds make v8-attachment-safety-check

## Matrix coverage

- safe PDF base64 attachment
- quoted-printable text attachment
- suspicious HTML attachment
- active SVG attachment
- generated filename fallback
- unsupported transfer encoding
- invalid and unsurfaced part path rejection
- forced-download response headers
- audit field redaction

## Validation

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make v7-check
- make v8-check
- make security-check

## Evidence

- /home/foo/osmap-v8-evidence/osmap-v8-slice2-attachment-safety-matrix-repair-v1-20260620-044948Z
- /home/foo/osmap-v8-evidence/osmap-v8-slice2-attachment-safety-matrix-repair-v1-20260620-044948Z.tar.gz
- /home/foo/osmap-v8-evidence/osmap-v8-slice2-attachment-safety-matrix-repair-v1-20260620-044948Z.tar.gz.sha256
- sha256: 10de5b94a9c57bb67095c361514cb688a3b60cc409bf2c565379263eb20052f0