### PR TITLE
add v8 resource robustness regression matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Keep developer entrypoints obvious and conservative so operators and
 # collaborating developers do not have to memorize cargo subcommands.
 
-.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check v8-attachment-safety-check v8-mailbox-operation-check v8-session-integrity-check install-hooks run
+.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check v8-attachment-safety-check v8-mailbox-operation-check v8-session-integrity-check v8-resource-robustness-check install-hooks run
 
 build:
 	cargo build
@@ -53,6 +53,7 @@ v8-check:
 	sh maint/security/osmap-v8-attachment-safety-gate.sh
 	sh maint/security/osmap-v8-mailbox-operation-gate.sh
 	sh maint/security/osmap-v8-session-integrity-gate.sh
+	sh maint/security/osmap-v8-resource-robustness-gate.sh
 
 v8-mail-workflow-check:
 	sh maint/security/osmap-v8-mail-workflow-gate.sh
@@ -65,6 +66,9 @@ v8-mailbox-operation-check:
 
 v8-session-integrity-check:
 	sh maint/security/osmap-v8-session-integrity-gate.sh
+
+v8-resource-robustness-check:
+	sh maint/security/osmap-v8-resource-robustness-gate.sh
 
 install-hooks:
 	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v7-rendering-regression-gate.sh maint/security/test-osmap-v7-rendering-regression-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py

--- a/docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md
+++ b/docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md
@@ -1,0 +1,87 @@
+# V8 Resource Exhaustion and Robustness Regression Matrix
+
+## Purpose
+
+V8 Slice 5 creates durable regression coverage for bounded behavior and fail-closed handling around resource pressure.
+
+This is not a feature expansion. The goal is to prevent already-supported daily-driver and security behavior from regressing after the V7 testing discipline incident.
+
+## Scope
+
+The Slice 5 matrix covers:
+
+- overlength session token rejection
+- configured mailbox name bound rejection
+- invalid message UID rejection
+- invalid same-mailbox move rejection
+- attachment download output bound enforcement
+- fail-closed public reason for oversized attachment output
+- audit-event session redaction on bounded rejection
+- deterministic sorting over larger synthetic message lists
+- deterministic sorting over larger synthetic search result lists
+
+## Fixture inventory
+
+Fixtures live under:
+
+```text
+tests/fixtures/resource_robustness/
+```
+
+| Fixture | Required outcome |
+|---|---|
+| `limits.env` | Bounded limit cases used by the Rust matrix |
+| `sort_matrix.tsv` | Deterministic sorting expectations for larger synthetic message sets |
+| `rejection_matrix.tsv` | Fail-closed request and output rejection expectations |
+
+## Test implementation
+
+The Rust integration test is:
+
+```text
+tests/v8_resource_robustness_matrix.rs
+```
+
+It validates:
+
+- fixture inventory
+- invalid request rejection before backend work
+- oversized attachment output rejection
+- public failure reason stability
+- audit redaction on resource-bound rejection
+- deterministic sort behavior over 256 synthetic message summaries
+- deterministic sort behavior over 256 synthetic search results
+
+## Gate
+
+The executable gate is:
+
+```text
+maint/security/osmap-v8-resource-robustness-gate.sh
+```
+
+It performs fixture and documentation presence checks, then executes the Rust test:
+
+```sh
+cargo test --test v8_resource_robustness_matrix
+```
+
+The aggregate V8 gate must run this Slice 5 gate through:
+
+```sh
+make v8-check
+```
+
+A dedicated convenience target is also provided:
+
+```sh
+make v8-resource-robustness-check
+```
+
+## Non-goals
+
+Slice 5 does not add new runtime limits.
+
+Slice 5 does not change production request handling.
+
+Slice 5 does not make final CI enforcement changes. That belongs to V8 Slice 6.

--- a/maint/security/osmap-v8-resource-robustness-gate.sh
+++ b/maint/security/osmap-v8-resource-robustness-gate.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V8_GATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_file() {
+	path=$1
+	if [ ! -s "$path" ]; then
+		echo "error: missing V8 resource robustness file: $path" >&2
+		exit 1
+	fi
+}
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V8 resource robustness requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+for path in \
+	docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md \
+	tests/v8_resource_robustness_matrix.rs \
+	tests/fixtures/resource_robustness/MANIFEST.md \
+	tests/fixtures/resource_robustness/limits.env \
+	tests/fixtures/resource_robustness/sort_matrix.tsv \
+	tests/fixtures/resource_robustness/rejection_matrix.tsv
+	do
+	require_file "$path"
+done
+
+require_text docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md "attachment download output bound enforcement"
+require_text docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md "audit-event session redaction"
+require_text docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md "deterministic sorting over larger synthetic message lists"
+require_text tests/v8_resource_robustness_matrix.rs "download_max_bytes: 3"
+require_text tests/v8_resource_robustness_matrix.rs "SESSION_TOKEN_HEX_LEN * 2"
+require_text tests/v8_resource_robustness_matrix.rs "synthetic_summaries(256)"
+require_text maint/security/osmap-v8-resource-robustness-gate.sh "cargo test --test v8_resource_robustness_matrix"
+require_text Makefile "osmap-v8-resource-robustness-gate.sh"
+
+echo "==> cargo test --test v8_resource_robustness_matrix"
+cargo test --test v8_resource_robustness_matrix
+
+echo "V8 resource robustness regression gate passed"

--- a/tests/fixtures/resource_robustness/MANIFEST.md
+++ b/tests/fixtures/resource_robustness/MANIFEST.md
@@ -1,0 +1,9 @@
+# V8 Resource Robustness Fixtures
+
+These fixtures support V8 Slice 5. They are synthetic and intentionally small.
+
+| Fixture | Regression objective |
+|---|---|
+| `limits.env` | Bounded limit cases used by the Rust matrix |
+| `sort_matrix.tsv` | Deterministic sorting expectations for larger synthetic message sets |
+| `rejection_matrix.tsv` | Fail-closed request and output rejection expectations |

--- a/tests/fixtures/resource_robustness/limits.env
+++ b/tests/fixtures/resource_robustness/limits.env
@@ -1,0 +1,5 @@
+attachment_download_max_bytes_case=3
+synthetic_message_count=256
+mailbox_name_max_len_case=8
+invalid_uid_case=0
+session_token_overlength_multiplier=2

--- a/tests/fixtures/resource_robustness/rejection_matrix.tsv
+++ b/tests/fixtures/resource_robustness/rejection_matrix.tsv
@@ -1,0 +1,6 @@
+case	input	expected
+attachment_download_max_bytes	download_max_bytes=3	temporarily_unavailable
+mailbox_name_max_len	Projects/OSMAP	invalid_request
+message_view_uid_zero	uid=0	invalid_request
+message_move_same_mailbox	INBOX->INBOX	invalid_request
+session_token_overlength	2x token length	invalid_request

--- a/tests/fixtures/resource_robustness/sort_matrix.tsv
+++ b/tests/fixtures/resource_robustness/sort_matrix.tsv
@@ -1,0 +1,4 @@
+case	count	sort	expected
+message_uid_asc	256	uid asc	first=1,last=256
+message_subject_asc	256	subject asc	first=1,last=256
+search_size_desc	256	size desc	first=256,last=1

--- a/tests/v8_resource_robustness_matrix.rs
+++ b/tests/v8_resource_robustness_matrix.rs
@@ -1,0 +1,253 @@
+use std::path::{Path, PathBuf};
+
+use osmap::attachment::{
+    AttachmentDownloadDecision, AttachmentDownloadPolicy, AttachmentDownloadPublicFailureReason,
+    AttachmentDownloadService,
+};
+use osmap::auth::{AuthenticationContext, AuthenticationPolicy, RequiredSecondFactor};
+use osmap::config::LogLevel;
+use osmap::logging::{EventCategory, LogEvent};
+use osmap::mailbox::{
+    sort_message_search_results, sort_message_summaries, MailboxEntry, MailboxListingPolicy,
+    MessageMovePolicy, MessageMoveRequest, MessageSearchResult, MessageSort, MessageSortColumn,
+    MessageSortDirection, MessageSummary, MessageView, MessageViewPolicy, MessageViewRequest,
+};
+use osmap::session::{SessionRecord, SessionToken, ValidatedSession, SESSION_TOKEN_HEX_LEN};
+
+const SESSION_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+fn repo_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn test_context() -> AuthenticationContext {
+    AuthenticationContext::new(
+        AuthenticationPolicy::default(),
+        "req-v8-resource-robustness",
+        "127.0.0.1",
+        "Firefox/V8-Resource-Robustness",
+    )
+    .expect("authentication context should be valid")
+}
+
+fn validated_session_fixture() -> ValidatedSession {
+    ValidatedSession {
+        record: SessionRecord {
+            session_id: SESSION_ID.to_string(),
+            csrf_token: "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+                .to_string(),
+            canonical_username: "alice@example.com".to_string(),
+            issued_at: 10,
+            expires_at: 100,
+            last_seen_at: 20,
+            revoked_at: None,
+            remote_addr: "127.0.0.1".to_string(),
+            user_agent: "Firefox/V8-Resource-Robustness".to_string(),
+            factor: RequiredSecondFactor::Totp,
+        },
+        audit_event: LogEvent::new(
+            LogLevel::Info,
+            EventCategory::Session,
+            "session_validated",
+            "browser session validated",
+        ),
+    }
+}
+
+fn message_view_from_fixture(raw_message: &str) -> MessageView {
+    let normalized = raw_message.replace("\r\n", "\n");
+    let (header_block, body_text) = normalized
+        .split_once("\n\n")
+        .expect("fixture should contain a header/body separator");
+    MessageView {
+        mailbox_name: "INBOX".to_string(),
+        uid: 909,
+        flags: vec!["\\Seen".to_string()],
+        date_received: "2026-06-20 06:00:00 +0000".to_string(),
+        size_virtual: normalized.len() as u64,
+        header_block: header_block.to_string(),
+        body_text: body_text.to_string(),
+    }
+}
+
+fn event_field<'a>(event: &'a LogEvent, key: &str) -> Option<&'a str> {
+    event
+        .fields
+        .iter()
+        .find(|field| field.key == key)
+        .map(|field| field.value.as_str())
+}
+
+fn sort(column: MessageSortColumn, direction: MessageSortDirection) -> MessageSort {
+    MessageSort { column, direction }
+}
+
+fn synthetic_summaries(count: u64) -> Vec<MessageSummary> {
+    (1..=count)
+        .rev()
+        .map(|uid| MessageSummary {
+            mailbox_name: "INBOX".to_string(),
+            uid,
+            flags: if uid % 2 == 0 {
+                vec!["\\Seen".to_string()]
+            } else {
+                vec!["\\Flagged".to_string()]
+            },
+            date_received: format!("2026-06-20 {:02}:00:00 +0000", uid % 24),
+            size_virtual: uid * 10,
+            subject: Some(format!("subject-{uid:03}")),
+            from: Some(format!("sender-{uid:03}@example.com")),
+        })
+        .collect()
+}
+
+fn synthetic_search_results(count: u64) -> Vec<MessageSearchResult> {
+    (1..=count)
+        .map(|uid| MessageSearchResult {
+            mailbox_name: if uid % 2 == 0 {
+                "INBOX".to_string()
+            } else {
+                "Archive".to_string()
+            },
+            uid,
+            flags: vec!["\\Seen".to_string()],
+            date_received: format!("2026-06-20 {:02}:30:00 +0000", uid % 24),
+            size_virtual: uid * 100,
+            subject: Some(format!("result-{uid:03}")),
+            from: Some(format!("result-{uid:03}@example.com")),
+        })
+        .collect()
+}
+
+fn summary_uids(messages: &[MessageSummary]) -> Vec<u64> {
+    messages.iter().map(|message| message.uid).collect()
+}
+
+fn search_uids(results: &[MessageSearchResult]) -> Vec<u64> {
+    results.iter().map(|result| result.uid).collect()
+}
+
+#[test]
+fn v8_resource_robustness_fixture_inventory_is_complete() {
+    for relative in [
+        "tests/fixtures/resource_robustness/MANIFEST.md",
+        "tests/fixtures/resource_robustness/limits.env",
+        "tests/fixtures/resource_robustness/sort_matrix.tsv",
+        "tests/fixtures/resource_robustness/rejection_matrix.tsv",
+        "docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md",
+        "maint/security/osmap-v8-resource-robustness-gate.sh",
+    ] {
+        assert!(repo_path(relative).is_file(), "missing {relative}");
+    }
+
+    assert!(include_str!("fixtures/resource_robustness/limits.env")
+        .contains("synthetic_message_count=256"));
+    assert!(
+        include_str!("fixtures/resource_robustness/sort_matrix.tsv").contains("message_uid_asc")
+    );
+    assert!(
+        include_str!("fixtures/resource_robustness/rejection_matrix.tsv")
+            .contains("attachment_download_max_bytes")
+    );
+}
+
+#[test]
+fn v8_resource_robustness_matrix_rejects_bounded_invalid_inputs() {
+    assert!(
+        SessionToken::new("a".repeat(SESSION_TOKEN_HEX_LEN * 2)).is_err(),
+        "overlength session tokens must be rejected"
+    );
+
+    assert!(
+        MailboxEntry::new(
+            MailboxListingPolicy {
+                mailbox_name_max_len: 8,
+                max_mailboxes: 4,
+            },
+            "Projects/OSMAP",
+        )
+        .is_err(),
+        "mailbox names beyond the configured bound must be rejected"
+    );
+
+    assert!(
+        MessageViewRequest::new(MessageViewPolicy::default(), "INBOX", 0).is_err(),
+        "zero UID message view requests must be rejected"
+    );
+
+    assert!(
+        MessageMoveRequest::new(MessageMovePolicy::default(), "INBOX", "INBOX", 42).is_err(),
+        "same-mailbox move requests must be rejected"
+    );
+}
+
+#[test]
+fn v8_resource_robustness_matrix_fails_closed_for_oversized_attachment_output() {
+    let policy = AttachmentDownloadPolicy {
+        download_max_bytes: 3,
+        ..AttachmentDownloadPolicy::default()
+    };
+    let outcome = AttachmentDownloadService::new(policy).download_for_validated_session(
+        &test_context(),
+        &validated_session_fixture(),
+        &message_view_from_fixture(include_str!("fixtures/attachments/safe_pdf_base64.eml")),
+        "1.2",
+    );
+
+    assert_eq!(
+        outcome.decision,
+        AttachmentDownloadDecision::Denied {
+            public_reason: AttachmentDownloadPublicFailureReason::TemporarilyUnavailable
+        }
+    );
+    assert_eq!(outcome.audit_event.action, "attachment_download_failed");
+    assert_eq!(
+        event_field(&outcome.audit_event, "public_reason"),
+        Some("temporarily_unavailable")
+    );
+    assert_eq!(
+        event_field(&outcome.audit_event, "audit_reason"),
+        Some("output_rejected")
+    );
+    assert!(
+        event_field(&outcome.audit_event, "session_ref").is_some(),
+        "bounded rejection should still include a redacted session reference"
+    );
+    assert!(
+        event_field(&outcome.audit_event, "session_id").is_none(),
+        "bounded rejection must not log raw session_id"
+    );
+}
+
+#[test]
+fn v8_resource_robustness_matrix_sorts_larger_synthetic_message_sets_deterministically() {
+    let mut by_uid = synthetic_summaries(256);
+    sort_message_summaries(
+        &mut by_uid,
+        Some(sort(MessageSortColumn::Uid, MessageSortDirection::Asc)),
+    );
+    let by_uid_order = summary_uids(&by_uid);
+    assert_eq!(by_uid_order.first(), Some(&1));
+    assert_eq!(by_uid_order.last(), Some(&256));
+    assert_eq!(by_uid_order.len(), 256);
+
+    let mut by_subject = synthetic_summaries(256);
+    sort_message_summaries(
+        &mut by_subject,
+        Some(sort(MessageSortColumn::Subject, MessageSortDirection::Asc)),
+    );
+    let by_subject_order = summary_uids(&by_subject);
+    assert_eq!(by_subject_order.first(), Some(&1));
+    assert_eq!(by_subject_order.last(), Some(&256));
+    assert_eq!(by_subject_order.len(), 256);
+
+    let mut search_by_size = synthetic_search_results(256);
+    sort_message_search_results(
+        &mut search_by_size,
+        Some(sort(MessageSortColumn::Size, MessageSortDirection::Desc)),
+    );
+    let search_order = search_uids(&search_by_size);
+    assert_eq!(search_order.first(), Some(&256));
+    assert_eq!(search_order.last(), Some(&1));
+    assert_eq!(search_order.len(), 256);
+}


### PR DESCRIPTION
## Summary

Adds the V8 Slice 5 resource exhaustion and robustness regression matrix.

This slice protects existing bounded behavior and fail-closed handling. It does not add new end-user features.

## Changes

- Adds synthetic resource robustness fixtures
- Adds tests/v8_resource_robustness_matrix.rs
- Adds docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md
- Adds maint/security/osmap-v8-resource-robustness-gate.sh
- Wires the resource robustness gate into make v8-check
- Adds make v8-resource-robustness-check

## Matrix coverage

- overlength session token rejection
- configured mailbox name bound rejection
- invalid message UID rejection
- invalid same-mailbox move rejection
- attachment download output bound enforcement
- fail-closed public reason for oversized attachment output
- audit-event session redaction on bounded rejection
- deterministic sorting over larger synthetic message lists
- deterministic sorting over larger synthetic search result lists

## Validation

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make v7-check
- make v8-check
- make security-check

## Evidence

- /home/foo/osmap-v8-evidence/osmap-v8-slice5-resource-robustness-matrix-v1-20260620-092636Z
- /home/foo/osmap-v8-evidence/osmap-v8-slice5-resource-robustness-matrix-v1-20260620-092636Z.tar.gz
- /home/foo/osmap-v8-evidence/osmap-v8-slice5-resource-robustness-matrix-v1-20260620-092636Z.tar.gz.sha256