### PR TITLE
enforce v8 final regression gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Keep developer entrypoints obvious and conservative so operators and
 # collaborating developers do not have to memorize cargo subcommands.
 
-.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check v8-attachment-safety-check v8-mailbox-operation-check v8-session-integrity-check v8-resource-robustness-check install-hooks run
+.PHONY: build check test lint fmt-check supply-chain-check security-check release-check v6-check v7-check v7-rendering-regression-check v8-check v8-mail-workflow-check v8-attachment-safety-check v8-mailbox-operation-check v8-session-integrity-check v8-resource-robustness-check v8-final-regression-check install-hooks run
 
 build:
 	cargo build
@@ -54,6 +54,7 @@ v8-check:
 	sh maint/security/osmap-v8-mailbox-operation-gate.sh
 	sh maint/security/osmap-v8-session-integrity-gate.sh
 	sh maint/security/osmap-v8-resource-robustness-gate.sh
+	sh maint/security/osmap-v8-final-regression-gate.sh
 
 v8-mail-workflow-check:
 	sh maint/security/osmap-v8-mail-workflow-gate.sh
@@ -69,6 +70,9 @@ v8-session-integrity-check:
 
 v8-resource-robustness-check:
 	sh maint/security/osmap-v8-resource-robustness-gate.sh
+
+v8-final-regression-check:
+	sh maint/security/osmap-v8-final-regression-gate.sh
 
 install-hooks:
 	chmod +x .githooks/pre-commit .githooks/pre-push maint/security/osmap-security-check.sh maint/security/osmap-supply-chain-check.sh maint/security/osmap-release-check.sh maint/security/osmap-v4-hostile-assurance-gate.sh maint/security/osmap-v4-release-tuple-gate.sh maint/security/osmap-v4-security-claim-matrix-gate.sh maint/security/osmap-v5-boundary-gate.sh maint/security/osmap-v6-retirement-readiness-gate.sh maint/security/osmap-v7-boundary-hardening-gate.sh maint/security/osmap-v7-rendering-regression-gate.sh maint/security/test-osmap-v7-rendering-regression-gate.sh maint/security/osmap-v6-evidence-archive.sh maint/security/osmap-evidence-metadata.sh maint/security/osmap-cwe-top25-guard.sh maint/security/osmap-cwe-top25-guard.py

--- a/docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
+++ b/docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
@@ -1,0 +1,51 @@
+# V8 Final Regression Gate Close-out
+
+## Purpose
+
+V8 was created because a production-visible rendering regression survived until V7 after testing discipline weakened after V2.
+
+The V8 close-out objective is not feature growth. The objective is regression confidence.
+
+## V8 close-out standard
+
+V8 is complete only when:
+
+- each V8 slice has a durable regression matrix
+- each matrix has dedicated fixtures where fixtures are applicable
+- each matrix has a Rust integration test or a shell gate
+- each matrix has a dedicated executable gate under `maint/security/`
+- `make v8-check` runs every V8 gate
+- `make security-check` invokes the V8 aggregate gate
+- CI runs `security-check`
+- final evidence captures formatting, tests, clippy, cargo audit, V7 gates, V8 gates, and security-check
+
+## Completed V8 slices
+
+| Slice | Scope | Required gate |
+|---|---|---|
+| Slice 0 | Stabilization framework | `maint/security/osmap-v8-stabilization-gate.sh` |
+| Slice 1 | Mail workflow regression matrix | `maint/security/osmap-v8-mail-workflow-gate.sh` |
+| Slice 2 | Attachment safety regression matrix | `maint/security/osmap-v8-attachment-safety-gate.sh` |
+| Slice 3 | Mailbox operation regression matrix | `maint/security/osmap-v8-mailbox-operation-gate.sh` |
+| Slice 4 | Session integrity regression matrix | `maint/security/osmap-v8-session-integrity-gate.sh` |
+| Slice 5 | Resource exhaustion and robustness matrix | `maint/security/osmap-v8-resource-robustness-gate.sh` |
+| Slice 6 | Final regression gate closure | `maint/security/osmap-v8-final-regression-gate.sh` |
+
+## Enforcement chain
+
+The expected local and CI enforcement chain is:
+
+```text
+make security-check
+  -> maint/security/osmap-security-check.sh
+     -> make v8-check
+        -> all V8 gates, including this final close-out gate
+```
+
+## Non-goals
+
+V8 does not claim feature parity with Roundcube.
+
+V8 does not add new user-facing functionality.
+
+V8 does not replace V4 hostile-content containment, V5 boundary hardening, V6 retirement readiness, or V7 rendering regression coverage. It preserves and extends regression confidence around them.

--- a/maint/security/osmap-security-check.sh
+++ b/maint/security/osmap-security-check.sh
@@ -101,6 +101,9 @@ if [ "$run_cargo_phases" -eq 1 ]; then
 
 	echo "==> validating V7 rendering regression gate wrapper behavior"
 	sh maint/security/test-osmap-v7-rendering-regression-gate.sh
+
+	echo "==> validating V8 final regression aggregate gate"
+	make v8-check
 fi
 
 echo "==> validating publication hygiene"

--- a/maint/security/osmap-v8-final-regression-gate.sh
+++ b/maint/security/osmap-v8-final-regression-gate.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=${OSMAP_V8_GATE_REPO_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$repo_root"
+
+require_file() {
+	path=$1
+	if [ ! -s "$path" ]; then
+		echo "error: missing V8 final close-out file: $path" >&2
+		exit 1
+	fi
+}
+
+require_executable() {
+	path=$1
+	require_file "$path"
+	if [ ! -x "$path" ]; then
+		echo "error: V8 gate is not executable: $path" >&2
+		exit 1
+	fi
+}
+
+require_text() {
+	path=$1
+	text=$2
+	if ! grep -Fq "$text" "$path"; then
+		echo "error: missing V8 final close-out requirement in $path: $text" >&2
+		exit 1
+	fi
+}
+
+for path in \
+	docs/V8_STABILIZATION_PROGRAM.md \
+	docs/V8_MAIL_WORKFLOW_MATRIX.md \
+	docs/V8_ATTACHMENT_SAFETY_MATRIX.md \
+	docs/V8_MAILBOX_OPERATION_MATRIX.md \
+	docs/V8_SESSION_INTEGRITY_MATRIX.md \
+	docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md \
+	docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
+	do
+	require_file "$path"
+done
+
+for path in \
+	tests/v8_mail_workflow_matrix.rs \
+	tests/v8_attachment_safety_matrix.rs \
+	tests/v8_mailbox_operation_matrix.rs \
+	tests/v8_session_integrity_matrix.rs \
+	tests/v8_resource_robustness_matrix.rs
+	do
+	require_file "$path"
+done
+
+for path in \
+	tests/fixtures/mail_workflows/MANIFEST.md \
+	tests/fixtures/attachments/MANIFEST.md \
+	tests/fixtures/mailbox_operations/MANIFEST.md \
+	tests/fixtures/session_integrity/MANIFEST.md \
+	tests/fixtures/resource_robustness/MANIFEST.md
+	do
+	require_file "$path"
+done
+
+for path in \
+	maint/security/osmap-v8-stabilization-gate.sh \
+	maint/security/osmap-v8-mail-workflow-gate.sh \
+	maint/security/osmap-v8-attachment-safety-gate.sh \
+	maint/security/osmap-v8-mailbox-operation-gate.sh \
+	maint/security/osmap-v8-session-integrity-gate.sh \
+	maint/security/osmap-v8-resource-robustness-gate.sh \
+	maint/security/osmap-v8-final-regression-gate.sh
+	do
+	require_executable "$path"
+done
+
+require_text Makefile "v8-check:"
+require_text Makefile "v8-final-regression-check:"
+require_text Makefile "osmap-v8-stabilization-gate.sh"
+require_text Makefile "osmap-v8-mail-workflow-gate.sh"
+require_text Makefile "osmap-v8-attachment-safety-gate.sh"
+require_text Makefile "osmap-v8-mailbox-operation-gate.sh"
+require_text Makefile "osmap-v8-session-integrity-gate.sh"
+require_text Makefile "osmap-v8-resource-robustness-gate.sh"
+require_text Makefile "osmap-v8-final-regression-gate.sh"
+
+require_text maint/security/osmap-security-check.sh "make v8-check"
+require_text maint/security/osmap-security-check.sh "validating V8 final regression aggregate gate"
+
+require_text docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md "make security-check"
+require_text docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md "make v8-check"
+require_text docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md "V8 does not claim feature parity with Roundcube"
+
+echo "V8 final regression close-out gate passed"


### PR DESCRIPTION
## Summary

Completes V8 Slice 6 by enforcing the final V8 regression gate.

This slice closes V8 by ensuring the aggregate V8 gate is part of the standard security-check path.

## Changes

- Adds docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
- Adds maint/security/osmap-v8-final-regression-gate.sh
- Adds v8-final-regression-check
- Wires the final regression gate into make v8-check
- Wires make v8-check into maint/security/osmap-security-check.sh

## Validation

- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo audit
- make v7-check
- make v8-check
- make v8-final-regression-check
- make security-check

## Evidence

- /home/foo/osmap-v8-evidence/osmap-v8-slice6-final-regression-gate-repair-v2-20260620-110959Z
- /home/foo/osmap-v8-evidence/osmap-v8-slice6-final-regression-gate-repair-v2-20260620-110959Z.tar.gz
- /home/foo/osmap-v8-evidence/osmap-v8-slice6-final-regression-gate-repair-v2-20260620-110959Z.tar.gz.sha256