### PR TITLE
[codex] align V8 documentation with completed stabilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,16 @@ has not been completed.
 V7 boundary hardening was deployed to `mail.blackbagsecurity.com` on June 18,
 2026, then reopened and rolled back after repeated browser-entry outages. The
 code closes headerless-request buffering, weak TOTP secret, forwarded client
-IP, and compose content-type findings, but it is not the current production
-binary. V7 must pass the browser availability invariant and a real
-operator-controlled login hold before redeployment or closure.
+IP, compose content-type, and file-backed state findings, but it is not the
+current production binary. V7 must pass the browser availability invariant and
+a real operator-controlled login hold before redeployment or closure.
+
+V8 stabilization was completed in source on June 20, 2026. It adds five
+focused regression matrices for mail workflows, attachment safety, mailbox
+operations, session integrity, and resource robustness. The aggregate
+`make v8-check` gate is mandatory through `make security-check` and CI. V8 is
+not a production deployment or a new feature release, and it does not change
+the reopened V7 production status.
 
 The current implementation includes:
 
@@ -550,10 +557,36 @@ risk, and production evidence summary is:
 
 - [`docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md`](docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md)
 
-V7 is implemented but reopened and not production-approved. Four original
-findings are closed in code. The file-state finding remains partially closed,
-and production availability after a real login must be proven before V7 can be
-redeployed or merged.
+V7 is implemented but reopened and not production-approved. All five original
+findings are closed in source, including the post-V7 throttle transaction
+locking follow-up. Production availability after a real login must still be
+proven before V7 can be redeployed or closed.
+
+## V8 Stabilization and Regression Coverage
+
+Version 8 is a source-level stabilization milestone. It converts the V7
+rendering-regression lesson into mandatory regression coverage without adding
+user-facing features or widening the trust boundary.
+
+The authoritative V8 program, matrices, and close-out record are:
+
+- [`docs/V8_STABILIZATION_PROGRAM.md`](docs/V8_STABILIZATION_PROGRAM.md)
+- [`docs/V8_MAIL_WORKFLOW_MATRIX.md`](docs/V8_MAIL_WORKFLOW_MATRIX.md)
+- [`docs/V8_ATTACHMENT_SAFETY_MATRIX.md`](docs/V8_ATTACHMENT_SAFETY_MATRIX.md)
+- [`docs/V8_MAILBOX_OPERATION_MATRIX.md`](docs/V8_MAILBOX_OPERATION_MATRIX.md)
+- [`docs/V8_SESSION_INTEGRITY_MATRIX.md`](docs/V8_SESSION_INTEGRITY_MATRIX.md)
+- [`docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md`](docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md)
+- [`docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md`](docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md)
+
+The short form is:
+
+- five focused Rust integration-test matrices protect existing behavior
+- each matrix has a dedicated executable gate under `maint/security/`
+- `make v8-check` runs the full V8 suite
+- `make security-check` and the GitHub Actions security workflow enforce V8
+- external slice evidence archives and SHA256 sidecars exist under the
+  operator evidence root
+- V8 makes no production deployment, Roundcube parity, or V7 closure claim
 
 ## Target Users
 

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -6720,3 +6720,30 @@ acquisition failure fails closed, and an RAII guard releases the lock.
 Decision: the final explicit V7 state-store race is closed for cooperating
 processes on one host. This does not claim distributed cross-host locking, and
 the lock is not held across external authentication, mailbox, or send work.
+
+## 2026-06-20, Close V8 source stabilization and align project documentation
+
+V8 converts the V7 rendering-regression lesson into five focused regression
+matrices for mail workflows, attachment safety, mailbox operations, session
+integrity, and resource robustness. Each matrix has a dedicated executable
+gate, `make v8-check` aggregates the complete V8 suite, and
+`make security-check` makes that suite mandatory in the repository-owned CI
+workflow.
+
+The merged V8 implementation commit is
+`ac2dfdd856011ec99a5238079f9eda8073577d83`. The five Rust matrices execute 25
+focused integration tests. External evidence archives and SHA256 sidecars
+exist under the operator evidence root and passed checksum verification during
+the June 20 documentation review.
+
+The review also clarified fixture semantics. Mail workflow and attachment EML
+fixtures are executed directly. The mailbox, session, and resource text, TSV,
+and ENV files are reviewable inventories, while their corresponding vectors
+and expected outcomes are encoded in the Rust tests. Documentation now states
+that distinction instead of implying that every tabular file is parsed at
+runtime.
+
+Decision: V8 is complete as a source-level stabilization milestone. It is not
+a feature release, does not change the frozen V4 release-evidence tuple, does
+not claim a new production deployment, and does not close the reopened V7
+production availability milestone.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,8 @@ The repository deliberately separates:
 - Agent-facing collaboration guidance in the tracked repository root file
   `AGENTS.md`
 
-As of June 18, 2026, the project has substantive public-safe documentation
-through the Version 7 boundary-hardening deployment. The current
+As of June 20, 2026, the project has substantive public-safe documentation
+through the Version 8 source-level stabilization close-out. The current
 baseline was built from:
 
 - private early project planning notes, distilled into public-safe docs
@@ -33,6 +33,8 @@ baseline was built from:
   incomplete-retirement-closeout records
 - repo-owned Version 7 finding reevaluation, implementation, test, deployment,
   rollback, and production-validation record
+- repo-owned Version 8 stabilization program, regression matrices, executable
+  gates, CI enforcement, and external evidence archives
 
 The documents in this folder are written for two audiences:
 
@@ -66,6 +68,14 @@ Current public documentation map:
 - `V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md`
 - `V7_BROWSER_AVAILABILITY_INVARIANT.md`
 - `POST_V7_THROTTLE_TRANSACTION_LOCKING.md`
+- `V7_RENDERING_REGRESSION_CLOSEOUT.md`
+- `V8_STABILIZATION_PROGRAM.md`
+- `V8_MAIL_WORKFLOW_MATRIX.md`
+- `V8_ATTACHMENT_SAFETY_MATRIX.md`
+- `V8_MAILBOX_OPERATION_MATRIX.md`
+- `V8_SESSION_INTEGRITY_MATRIX.md`
+- `V8_RESOURCE_ROBUSTNESS_MATRIX.md`
+- `V8_FINAL_REGRESSION_GATE_CLOSEOUT.md`
 - `BUILD_AND_RELEASE_PROCESS.md`
 - `IMPLEMENTATION_PLAN.md`
 - `PROOF_OF_CONCEPT_PLAN.md`
@@ -176,9 +186,13 @@ rendering, malware prevention, or Roundcube parity. Version 5 records deployed
 identity, Host/origin, and response-boundary hardening without changing those
 product-scope limits. Version 6 defines controlled Roundcube retirement
 readiness for a selected cohort and remains incomplete until its sanitized
-live-evidence and closeout gates pass. Requested additional functionality and
-Thunderbird-like UX polish remain future-version work unless a later
-definition explicitly brings them into scope.
+live-evidence and closeout gates pass. Version 7 remains reopened for
+production because browser availability and real-login hold evidence are still
+required. Version 8 adds source-level regression coverage and mandatory CI
+enforcement, but does not deploy a new production binary or close V7.
+Requested additional functionality and Thunderbird-like UX polish remain
+future-version work unless a later definition explicitly brings them into
+scope.
 
 Some later-phase or deferred documents remain placeholders so the intended
 documentation map is visible without publishing private notes prematurely.

--- a/docs/V8_ATTACHMENT_SAFETY_MATRIX.md
+++ b/docs/V8_ATTACHMENT_SAFETY_MATRIX.md
@@ -90,10 +90,14 @@ make v8-attachment-safety-check
 
 ## Non-goals
 
-Slice 2 does not implement mailbox listing, search, sort, move, or archive coverage. That belongs to V8 Slice 3.
+Slice 2 does not implement mailbox listing, search, sort, move, or archive
+coverage. V8 Slice 3 provides that matrix.
 
-Slice 2 does not implement session integrity coverage. That belongs to V8 Slice 4.
+Slice 2 does not implement session integrity coverage. V8 Slice 4 provides
+that matrix.
 
-Slice 2 does not implement resource exhaustion and robustness coverage. That belongs to V8 Slice 5.
+Slice 2 does not implement resource exhaustion and robustness coverage. V8
+Slice 5 provides that matrix.
 
-Slice 2 does not make final CI enforcement changes. That belongs to V8 Slice 6.
+Slice 2 does not make final CI enforcement changes. V8 Slice 6 completed
+aggregate CI enforcement.

--- a/docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
+++ b/docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md
@@ -42,6 +42,32 @@ make security-check
         -> all V8 gates, including this final close-out gate
 ```
 
+## Review and evidence status
+
+The V8 implementation merged to `main` at
+`ac2dfdd856011ec99a5238079f9eda8073577d83` on June 20, 2026.
+
+A documentation and implementation review on June 20, 2026 confirmed:
+
+- `make v8-check` passes all five Rust matrices and both structural gates
+- the five matrices execute 25 focused integration tests
+- `make security-check` invokes the V8 aggregate gate
+- the GitHub Actions security workflow invokes `make security-check`
+- external slice archives and their SHA256 sidecars exist under
+  `$HOME/osmap-v8-evidence`
+- every discovered V8 archive passes its recorded SHA256 verification
+
+The mail workflow and attachment matrices execute their EML fixtures directly.
+The mailbox, session, and resource matrices also carry reviewable text, TSV, or
+ENV inventories. Except for the mailbox message-view EML and the attachment EML
+used by the resource matrix, those inventory files are not parsed at test
+runtime. Their corresponding vectors and assertions are encoded directly in
+the Rust matrices.
+
+This review does not claim that the V8 implementation commit is the currently
+deployed production binary. V7 remains reopened for production availability
+and real-login hold proof.
+
 ## Non-goals
 
 V8 does not claim feature parity with Roundcube.

--- a/docs/V8_MAILBOX_OPERATION_MATRIX.md
+++ b/docs/V8_MAILBOX_OPERATION_MATRIX.md
@@ -37,6 +37,11 @@ tests/fixtures/mailbox_operations/
 | `message_view.eml` | Single-message retrieval metadata and body fixture |
 | `move_operations.tsv` | Valid move, same-mailbox rejection, and zero-UID rejection cases |
 
+`message_view.eml` is executed directly by the Rust matrix. The text and TSV
+files are reviewable inventories whose corresponding test vectors and expected
+outcomes are encoded in `tests/v8_mailbox_operation_matrix.rs`. They are not
+runtime data inputs.
+
 ## Test implementation
 
 The Rust integration test is:
@@ -93,8 +98,11 @@ make v8-mailbox-operation-check
 
 Slice 3 does not implement attachment download safety coverage. That is already covered by V8 Slice 2.
 
-Slice 3 does not implement session integrity coverage. That belongs to V8 Slice 4.
+Slice 3 does not implement session integrity coverage. V8 Slice 4 provides
+that matrix.
 
-Slice 3 does not implement resource exhaustion and robustness coverage. That belongs to V8 Slice 5.
+Slice 3 does not implement resource exhaustion and robustness coverage. V8
+Slice 5 provides that matrix.
 
-Slice 3 does not make final CI enforcement changes. That belongs to V8 Slice 6.
+Slice 3 does not make final CI enforcement changes. V8 Slice 6 completed
+aggregate CI enforcement.

--- a/docs/V8_MAIL_WORKFLOW_MATRIX.md
+++ b/docs/V8_MAIL_WORKFLOW_MATRIX.md
@@ -94,12 +94,17 @@ make v8-check
 
 ## Non-goals
 
-Slice 1 does not implement attachment filename safety coverage. That belongs to V8 Slice 2.
+Slice 1 does not implement attachment filename safety coverage. V8 Slice 2
+provides that matrix.
 
-Slice 1 does not implement mailbox state behavior coverage. That belongs to V8 Slice 3.
+Slice 1 does not implement mailbox state behavior coverage. V8 Slice 3
+provides that matrix.
 
-Slice 1 does not implement session integrity coverage. That belongs to V8 Slice 4.
+Slice 1 does not implement session integrity coverage. V8 Slice 4 provides
+that matrix.
 
-Slice 1 does not implement resource exhaustion coverage. That belongs to V8 Slice 5.
+Slice 1 does not implement resource exhaustion coverage. V8 Slice 5 provides
+that matrix.
 
-Slice 1 does not make CI enforcement final. That belongs to V8 Slice 6.
+Slice 1 does not make CI enforcement final. V8 Slice 6 completed aggregate CI
+enforcement.

--- a/docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md
+++ b/docs/V8_RESOURCE_ROBUSTNESS_MATRIX.md
@@ -34,6 +34,11 @@ tests/fixtures/resource_robustness/
 | `sort_matrix.tsv` | Deterministic sorting expectations for larger synthetic message sets |
 | `rejection_matrix.tsv` | Fail-closed request and output rejection expectations |
 
+These ENV and TSV files are reviewable inventories. The Rust matrix encodes
+the corresponding bounds and expected outcomes directly, generates the larger
+synthetic message sets in memory, and executes the attachment EML fixture used
+by the output-bound case. The tabular files are not runtime data inputs.
+
 ## Test implementation
 
 The Rust integration test is:
@@ -84,4 +89,5 @@ Slice 5 does not add new runtime limits.
 
 Slice 5 does not change production request handling.
 
-Slice 5 does not make final CI enforcement changes. That belongs to V8 Slice 6.
+Slice 5 does not make final CI enforcement changes. V8 Slice 6 completed
+aggregate CI enforcement.

--- a/docs/V8_SESSION_INTEGRITY_MATRIX.md
+++ b/docs/V8_SESSION_INTEGRITY_MATRIX.md
@@ -39,6 +39,11 @@ tests/fixtures/session_integrity/
 | `timeout_cases.tsv` | Active, expired, and idle-timeout behavior |
 | `revocation_cases.tsv` | Logout, revoke-current, revoke-except-current, and revoke-all behavior |
 
+These ENV and TSV files are reviewable lifecycle inventories. The Rust matrix
+encodes and executes the corresponding values directly so session timing,
+randomness, storage, and revocation behavior remain deterministic. The files
+are not runtime data inputs.
+
 ## Test implementation
 
 The Rust integration test is:
@@ -93,6 +98,8 @@ make v8-session-integrity-check
 
 Slice 4 does not implement mailbox operation coverage. That is already covered by V8 Slice 3.
 
-Slice 4 does not implement resource exhaustion and robustness coverage. That belongs to V8 Slice 5.
+Slice 4 does not implement resource exhaustion and robustness coverage. V8
+Slice 5 provides that matrix.
 
-Slice 4 does not make final CI enforcement changes. That belongs to V8 Slice 6.
+Slice 4 does not make final CI enforcement changes. V8 Slice 6 completed
+aggregate CI enforcement.

--- a/docs/V8_STABILIZATION_PROGRAM.md
+++ b/docs/V8_STABILIZATION_PROGRAM.md
@@ -77,6 +77,23 @@ The planned matrices are:
 
 The final release gate must aggregate these checks through `make v8-check`.
 
+## Current status
+
+V8 source implementation is complete as of June 20, 2026.
+
+The completed implementation provides:
+
+- five Rust integration-test matrices
+- dedicated executable gates for every matrix
+- an aggregate `make v8-check` entry point
+- enforcement from `make security-check`
+- enforcement from the GitHub Actions `security-check` workflow
+- external slice evidence archives with SHA256 sidecars
+
+This status is source-level only. V8 does not claim a production deployment,
+does not close the reopened V7 production milestone, and does not change the
+frozen V4 release-evidence tuple.
+
 ## Non-goals
 
 V8 does not aim to add general end-user features.
@@ -140,17 +157,14 @@ $HOME/osmap-v8-evidence/<slice-name>-<timestamp>.tar.gz.sha256
 
 The evidence archive must include the validation transcript and the final commit hash for the slice.
 
-## CI expectations
+## CI enforcement
 
 The current CI enforcement path is the `security-check` workflow. That workflow checks out the repository, installs the Rust toolchain, and runs `make security-check`.
 
-During Slice 0, `make v8-check` is introduced as a foundation target. It validates that the V8 stabilization framework exists and that the repository has an explicit V8 gate entrypoint.
+Slice 0 introduced `make v8-check` as the foundation target and established the explicit V8 gate entrypoint.
 
-During Slices 1 through 5, the V8 matrix gates should be added as executable shell gates under `maint/security/` and wired into `make v8-check`.
+Slices 1 through 5 added executable matrix gates under `maint/security/` and wired them into `make v8-check`.
 
-During Slice 6, CI should be updated so V8 gates are mandatory. The expected enforcement path is either:
-
-- call `make v8-check` from `make security-check`, or
-- add an explicit CI step in `.github/workflows/security-check.yml` that runs `make v8-check`
-
-The Slice 6 implementation must ensure that CI fails on V8 regressions and that V7 protections remain enforced.
+Slice 6 made V8 mandatory by calling `make v8-check` from
+`make security-check`. The GitHub Actions workflow runs that repository-owned
+security gate, so V8 regressions fail CI while V7 protections remain enforced.

--- a/maint/security/osmap-v8-stabilization-gate.sh
+++ b/maint/security/osmap-v8-stabilization-gate.sh
@@ -40,7 +40,7 @@ require_text docs/V8_STABILIZATION_PROGRAM.md "attachment safety"
 require_text docs/V8_STABILIZATION_PROGRAM.md "mailbox operations"
 require_text docs/V8_STABILIZATION_PROGRAM.md "session integrity"
 require_text docs/V8_STABILIZATION_PROGRAM.md "resource exhaustion and robustness"
-require_text docs/V8_STABILIZATION_PROGRAM.md "During Slice 6, CI should be updated so V8 gates are mandatory."
+require_text docs/V8_STABILIZATION_PROGRAM.md "Slice 6 made V8 mandatory by calling"
 
 require_text Makefile "v8-check:"
 require_text Makefile "osmap-v8-stabilization-gate.sh"


### PR DESCRIPTION
## Summary

- add V8 source-stabilization status to the main README and documentation index
- record the completed V8 enforcement chain, external evidence verification, and merged implementation commit
- clarify which fixture files are executed directly and which are review inventories with vectors encoded in Rust
- update stale V7 wording to reflect that all five source findings are closed while production availability remains reopened
- replace future-tense Slice 6 documentation and keep the stabilization gate aligned
- add the June 20, 2026 V8 close-out decision record

## Why

The V8 implementation and gates were complete on `main`, but the broader project documentation still stopped at V7 and several V8 documents described completed work in future tense. The review also found that some TSV and ENV fixtures are review inventories rather than runtime-parsed inputs, which now has explicit documentation.

## Impact

Documentation now distinguishes source completion from production deployment. V8 does not claim a new production binary, Roundcube parity, or closure of the reopened V7 availability milestone.

## Validation

- `make v8-check`
- `make security-check`
- all discovered `$HOME/osmap-v8-evidence/*.tar.gz.sha256` sidecars verified successfully
- `git diff --check`
- documentation governance guard passed as part of `make security-check`