### PR TITLE
file submitted messages into sent

### DIFF
--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -6747,3 +6747,24 @@ Decision: V8 is complete as a source-level stabilization milestone. It is not
 a feature release, does not change the frozen V4 release-evidence tuple, does
 not claim a new production deployment, and does not close the reopened V7
 production availability milestone.
+
+## 2026-06-20, File accepted outbound messages into Sent
+
+Live delivery evidence showed that Postfix accepted an OSMAP compose submission
+while the sender's Dovecot `Sent` mailbox remained unchanged. The send path only
+called the local sendmail compatibility surface and treated that handoff as the
+end of the workflow.
+
+OSMAP now appends the same bounded RFC 5322 message bytes to `Sent` through a
+grant-authorized mailbox-helper operation backed by `doveadm save`. The helper
+grant binds the canonical user, mailbox, and message digest. Message size stays
+bounded by the compose policy after MIME expansion.
+
+Delivery remains authoritative. Sent-copy storage runs only after sendmail
+accepts the message. An append failure emits `sent_copy_store_failed` but does
+not report the already-delivered message as unsent, which avoids prompting a
+duplicate submission. Successful filing emits `sent_copy_stored`.
+
+Decision: accepted OSMAP submissions should appear in the authenticated
+sender's `Sent` mailbox without widening direct mailbox authority in the
+browser-facing runtime.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -38,9 +38,11 @@
   yet provide preview-oriented attachment behavior
 - The implementation now has a first outbound send path with reply and forward
   draft generation, bounded new attachment upload/submission behavior, and
-  explicit source-attachment selection for reply/forward sends. It still does
-  not automatically reattach original-message attachments, and source
-  attachment references are not yet saved across draft resume.
+  explicit source-attachment selection for reply/forward sends. Accepted
+  submissions are filed into the sender's `Sent` mailbox through the local
+  mailbox helper. It still does not automatically reattach original-message
+  attachments, and source attachment references are not yet saved across draft
+  resume.
 - The implementation now has a conservative rendering layer with both
   plain-text and sanitized-HTML modes, but it still does not provide
   inline image rendering, full rich-header coverage, or any external-resource

--- a/src/http.rs
+++ b/src/http.rs
@@ -57,27 +57,29 @@ use crate::logging::LogEvent;
 use crate::logging::{EventCategory, Logger};
 use crate::mailbox::{
     sort_message_search_results, sort_message_summaries, DoveadmMailboxListBackend,
-    DoveadmMessageListBackend, DoveadmMessageMoveBackend, DoveadmMessageSearchBackend,
-    DoveadmMessageViewBackend, MailboxEntry, MailboxListingDecision, MailboxListingPolicy,
-    MailboxListingService, MessageListDecision, MessageListPolicy, MessageListRequest,
-    MessageListService, MessageMoveDecision, MessageMoveOutcome, MessageMovePolicy,
-    MessageMoveRequest, MessageMoveService, MessageSearchDecision, MessageSearchField,
-    MessageSearchPolicy, MessageSearchRequest, MessageSearchResult, MessageSearchService,
-    MessageSort, MessageSummary, MessageViewDecision, MessageViewPolicy, MessageViewRequest,
-    MessageViewService,
+    DoveadmMessageAppendBackend, DoveadmMessageListBackend, DoveadmMessageMoveBackend,
+    DoveadmMessageSearchBackend, DoveadmMessageViewBackend, MailboxEntry, MailboxListingDecision,
+    MailboxListingPolicy, MailboxListingService, MessageAppendBackend, MessageAppendRequest,
+    MessageListDecision, MessageListPolicy, MessageListRequest, MessageListService,
+    MessageMoveDecision, MessageMoveOutcome, MessageMovePolicy, MessageMoveRequest,
+    MessageMoveService, MessageSearchDecision, MessageSearchField, MessageSearchPolicy,
+    MessageSearchRequest, MessageSearchResult, MessageSearchService, MessageSort, MessageSummary,
+    MessageViewDecision, MessageViewPolicy, MessageViewRequest, MessageViewService,
 };
 use crate::mailbox_helper::{
     MailboxHelperAttachmentDownloadBackend, MailboxHelperMailboxListBackend,
-    MailboxHelperMessageListBackend, MailboxHelperMessageMoveBackend,
-    MailboxHelperMessageSearchBackend, MailboxHelperMessageViewBackend, MailboxHelperPolicy,
+    MailboxHelperMessageAppendBackend, MailboxHelperMessageListBackend,
+    MailboxHelperMessageMoveBackend, MailboxHelperMessageSearchBackend,
+    MailboxHelperMessageViewBackend, MailboxHelperPolicy,
 };
 use crate::rendering::{
     HtmlDisplayPreference, PlainTextMessageRenderer, RenderedMessageView, RenderingPolicy,
 };
 use crate::send::{
-    ComposeDraft, ComposeIntent, ComposePolicy, ComposeRequest, SendmailSubmissionBackend,
-    SubmissionDecision, SubmissionOutcome, SubmissionPublicFailureReason, SubmissionService,
-    UploadedAttachment, DEFAULT_ATTACHMENT_MAX_BYTES, DEFAULT_TOTAL_ATTACHMENT_MAX_BYTES,
+    build_submission_message, ComposeDraft, ComposeIntent, ComposePolicy, ComposeRequest,
+    SendmailSubmissionBackend, SubmissionDecision, SubmissionOutcome,
+    SubmissionPublicFailureReason, SubmissionService, UploadedAttachment,
+    DEFAULT_ATTACHMENT_MAX_BYTES, DEFAULT_TOTAL_ATTACHMENT_MAX_BYTES,
 };
 use crate::session::{
     FileSessionStore, SessionService, SessionToken, SystemRandomSource, ValidatedSession,

--- a/src/http_gateway_mail.rs
+++ b/src/http_gateway_mail.rs
@@ -762,6 +762,68 @@ impl RuntimeBrowserGateway {
 
         match decision {
             SubmissionDecision::Submitted { .. } => {
+                let raw_message = build_submission_message(
+                    &validated_session.record.canonical_username,
+                    &request,
+                );
+                match MessageAppendRequest::new("Sent", raw_message) {
+                    Ok(append_request) => {
+                        let message_bytes = append_request.message.len();
+                        match self.build_message_append_backend().append_message(
+                            &validated_session.record.canonical_username,
+                            &append_request,
+                        ) {
+                            Ok(()) => audit_events.push(
+                                LogEvent::new(
+                                    LogLevel::Info,
+                                    EventCategory::Submission,
+                                    "sent_copy_stored",
+                                    "outbound message copy stored in Sent",
+                                )
+                                .with_field(
+                                    "canonical_username",
+                                    validated_session.record.canonical_username.clone(),
+                                )
+                                .with_field("mailbox_name", "Sent")
+                                .with_field("message_bytes", message_bytes.to_string())
+                                .with_field("request_id", context.request_id.clone()),
+                            ),
+                            Err(error) => audit_events.push(
+                                LogEvent::new(
+                                    LogLevel::Warn,
+                                    EventCategory::Submission,
+                                    "sent_copy_store_failed",
+                                    "outbound delivery succeeded but Sent copy storage failed",
+                                )
+                                .with_field(
+                                    "canonical_username",
+                                    validated_session.record.canonical_username.clone(),
+                                )
+                                .with_field("mailbox_name", "Sent")
+                                .with_field("backend", error.backend)
+                                .with_field("reason", error.reason)
+                                .with_field("request_id", context.request_id.clone()),
+                            ),
+                        }
+                    }
+                    Err(error) => audit_events.push(
+                        LogEvent::new(
+                            LogLevel::Warn,
+                            EventCategory::Submission,
+                            "sent_copy_store_failed",
+                            "outbound delivery succeeded but Sent copy validation failed",
+                        )
+                        .with_field(
+                            "canonical_username",
+                            validated_session.record.canonical_username.clone(),
+                        )
+                        .with_field("mailbox_name", "Sent")
+                        .with_field("backend", error.backend)
+                        .with_field("reason", error.reason)
+                        .with_field("request_id", context.request_id.clone()),
+                    ),
+                }
+
                 match throttle_service
                     .record_submission(context, &validated_session.record.canonical_username)
                 {

--- a/src/http_mailbox_backends.rs
+++ b/src/http_mailbox_backends.rs
@@ -149,6 +149,24 @@ impl RuntimeBrowserGateway {
         }
     }
 
+    /// Selects the backend used to file a delivered message into Sent.
+    pub(super) fn build_message_append_backend(&self) -> MessageAppendRuntimeBackend {
+        match &self.mailbox_helper_socket_path {
+            Some(socket_path) => {
+                MessageAppendRuntimeBackend::Helper(MailboxHelperMessageAppendBackend::new(
+                    socket_path,
+                    self.helper_grant_key_path(),
+                    self.expensive_route_helper_policy(),
+                ))
+            }
+            None => MessageAppendRuntimeBackend::Direct(
+                DoveadmMessageAppendBackend::new(SystemCommandExecutor, self.doveadm_path.clone())
+                    .with_userdb_socket_path(self.doveadm_userdb_socket_path.clone())
+                    .with_command_timeout_secs(self.expensive_route_command_timeout_secs()),
+            ),
+        }
+    }
+
     fn helper_grant_key_path(&self) -> &Path {
         self.mailbox_helper_grant_key_path
             .as_deref()
@@ -231,6 +249,26 @@ impl crate::mailbox::MessageMoveBackend for MessageMoveRuntimeBackend {
         match self {
             Self::Direct(backend) => backend.move_message(canonical_username, request),
             Self::Helper(backend) => backend.move_message(canonical_username, request),
+        }
+    }
+}
+
+/// Selects the current message-append backend without giving the browser
+/// runtime direct mailbox authority when a local helper is configured.
+pub(super) enum MessageAppendRuntimeBackend {
+    Direct(DoveadmMessageAppendBackend<SystemCommandExecutor>),
+    Helper(MailboxHelperMessageAppendBackend),
+}
+
+impl crate::mailbox::MessageAppendBackend for MessageAppendRuntimeBackend {
+    fn append_message(
+        &self,
+        canonical_username: &str,
+        request: &MessageAppendRequest,
+    ) -> Result<(), crate::mailbox::MailboxBackendError> {
+        match self {
+            Self::Direct(backend) => backend.append_message(canonical_username, request),
+            Self::Helper(backend) => backend.append_message(canonical_username, request),
         }
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -17,24 +17,25 @@ mod mailbox_parse;
 mod mailbox_service;
 
 pub use self::mailbox_backend::{
-    DoveadmMailboxListBackend, DoveadmMessageListBackend, DoveadmMessageMoveBackend,
-    DoveadmMessageSearchBackend, DoveadmMessageViewBackend,
+    DoveadmMailboxListBackend, DoveadmMessageAppendBackend, DoveadmMessageListBackend,
+    DoveadmMessageMoveBackend, DoveadmMessageSearchBackend, DoveadmMessageViewBackend,
 };
 pub(crate) use self::mailbox_model::validate_message_search_query;
 pub use self::mailbox_model::{
     sort_message_search_results, sort_message_summaries, MailboxAuditFailureReason, MailboxBackend,
     MailboxBackendError, MailboxEntry, MailboxListingDecision, MailboxListingOutcome,
-    MailboxListingPolicy, MailboxPublicFailureReason, MessageListBackend, MessageListDecision,
-    MessageListOutcome, MessageListPolicy, MessageListRequest, MessageMoveBackend,
-    MessageMoveDecision, MessageMoveOutcome, MessageMovePolicy, MessageMoveRequest,
-    MessageSearchBackend, MessageSearchDecision, MessageSearchField, MessageSearchOutcome,
-    MessageSearchPolicy, MessageSearchRequest, MessageSearchResult, MessageSort, MessageSortColumn,
-    MessageSortDirection, MessageSummary, MessageView, MessageViewBackend, MessageViewDecision,
-    MessageViewOutcome, MessageViewPolicy, MessageViewRequest, DEFAULT_MAILBOX_NAME_MAX_LEN,
-    DEFAULT_MAX_MAILBOXES, DEFAULT_MAX_MESSAGES, DEFAULT_MAX_SEARCH_RESULTS,
-    DEFAULT_MESSAGE_BODY_MAX_LEN, DEFAULT_MESSAGE_DATE_MAX_LEN,
-    DEFAULT_MESSAGE_FLAG_STRING_MAX_LEN, DEFAULT_MESSAGE_HEADER_MAX_LEN,
-    DEFAULT_SEARCH_HEADER_VALUE_MAX_LEN, DEFAULT_SEARCH_QUERY_MAX_LEN,
+    MailboxListingPolicy, MailboxPublicFailureReason, MessageAppendBackend, MessageAppendRequest,
+    MessageListBackend, MessageListDecision, MessageListOutcome, MessageListPolicy,
+    MessageListRequest, MessageMoveBackend, MessageMoveDecision, MessageMoveOutcome,
+    MessageMovePolicy, MessageMoveRequest, MessageSearchBackend, MessageSearchDecision,
+    MessageSearchField, MessageSearchOutcome, MessageSearchPolicy, MessageSearchRequest,
+    MessageSearchResult, MessageSort, MessageSortColumn, MessageSortDirection, MessageSummary,
+    MessageView, MessageViewBackend, MessageViewDecision, MessageViewOutcome, MessageViewPolicy,
+    MessageViewRequest, DEFAULT_MAILBOX_NAME_MAX_LEN, DEFAULT_MAX_MAILBOXES, DEFAULT_MAX_MESSAGES,
+    DEFAULT_MAX_SEARCH_RESULTS, DEFAULT_MESSAGE_APPEND_MAX_BYTES, DEFAULT_MESSAGE_BODY_MAX_LEN,
+    DEFAULT_MESSAGE_DATE_MAX_LEN, DEFAULT_MESSAGE_FLAG_STRING_MAX_LEN,
+    DEFAULT_MESSAGE_HEADER_MAX_LEN, DEFAULT_SEARCH_HEADER_VALUE_MAX_LEN,
+    DEFAULT_SEARCH_QUERY_MAX_LEN,
 };
 use self::mailbox_parse::{
     parse_doveadm_mailbox_list_output, parse_doveadm_message_list_output,
@@ -139,6 +140,7 @@ mod tests {
         execution: Result<CommandExecution, CommandExecutionError>,
         program: Option<String>,
         args: Option<Vec<String>>,
+        stdin_data: Option<Vec<u8>>,
         timeout_secs: Option<u64>,
     }
 
@@ -148,6 +150,7 @@ mod tests {
                 execution: Ok(execution),
                 program: None,
                 args: None,
+                stdin_data: None,
                 timeout_secs: None,
             }
         }
@@ -158,11 +161,12 @@ mod tests {
             &self,
             program: &str,
             args: &[String],
-            _stdin_data: &[u8],
+            stdin_data: &[u8],
         ) -> Result<CommandExecution, CommandExecutionError> {
             let mut state = self.borrow_mut();
             state.program = Some(program.to_string());
             state.args = Some(args.to_vec());
+            state.stdin_data = Some(stdin_data.to_vec());
             state.execution.clone()
         }
 
@@ -753,6 +757,45 @@ mod tests {
                 "9".to_string(),
             ]
         );
+        assert_eq!(recorded.timeout_secs, Some(3));
+    }
+
+    #[test]
+    fn message_append_uses_doveadm_save_with_message_on_stdin() {
+        let executor = Rc::new(std::cell::RefCell::new(StubCommandExecutor::success(
+            CommandExecution {
+                status_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            },
+        )));
+        let backend = DoveadmMessageAppendBackend::new(executor.clone(), "/usr/local/bin/doveadm")
+            .with_userdb_socket_path(Some(PathBuf::from("/var/run/osmap-userdb")))
+            .with_command_timeout_secs(3);
+        let message = b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nHello\r\n".to_vec();
+        let request =
+            MessageAppendRequest::new("Sent", message.clone()).expect("request should be valid");
+
+        backend
+            .append_message("alice@example.com", &request)
+            .expect("message append should succeed");
+
+        let recorded = executor.borrow();
+        assert_eq!(
+            recorded.args.as_ref().expect("args should be captured"),
+            &vec![
+                "-o".to_string(),
+                "stats_writer_socket_path=".to_string(),
+                "-o".to_string(),
+                "auth_socket_path=/var/run/osmap-userdb".to_string(),
+                "save".to_string(),
+                "-u".to_string(),
+                "alice@example.com".to_string(),
+                "-m".to_string(),
+                "Sent".to_string(),
+            ]
+        );
+        assert_eq!(recorded.stdin_data.as_deref(), Some(message.as_slice()));
         assert_eq!(recorded.timeout_secs, Some(3));
     }
 

--- a/src/mailbox_backend.rs
+++ b/src/mailbox_backend.rs
@@ -7,10 +7,10 @@ use super::{
     concise_command_diagnostics, parse_doveadm_mailbox_list_output,
     parse_doveadm_message_list_output, parse_doveadm_message_search_output,
     parse_doveadm_message_view_output, MailboxBackend, MailboxBackendError, MailboxEntry,
-    MailboxListingPolicy, MessageListBackend, MessageListPolicy, MessageListRequest,
-    MessageMoveBackend, MessageMoveRequest, MessageSearchBackend, MessageSearchPolicy,
-    MessageSearchRequest, MessageSearchResult, MessageSummary, MessageView, MessageViewBackend,
-    MessageViewPolicy, MessageViewRequest,
+    MailboxListingPolicy, MessageAppendBackend, MessageAppendRequest, MessageListBackend,
+    MessageListPolicy, MessageListRequest, MessageMoveBackend, MessageMoveRequest,
+    MessageSearchBackend, MessageSearchPolicy, MessageSearchRequest, MessageSearchResult,
+    MessageSummary, MessageView, MessageViewBackend, MessageViewPolicy, MessageViewRequest,
 };
 
 /// Lists mailboxes through `doveadm mailbox list`.
@@ -428,6 +428,91 @@ where
         if execution.status_code != 0 {
             return Err(MailboxBackendError {
                 backend: "doveadm-message-move",
+                reason: format!(
+                    "command exited with status {}: {}",
+                    execution.status_code,
+                    concise_command_diagnostics(&execution.stdout, &execution.stderr),
+                ),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Appends one complete message through `doveadm save`.
+pub struct DoveadmMessageAppendBackend<E> {
+    command_executor: E,
+    doveadm_path: PathBuf,
+    userdb_socket_path: Option<PathBuf>,
+    command_timeout_secs: u64,
+}
+
+impl<E> DoveadmMessageAppendBackend<E> {
+    /// Builds a backend using the supplied command executor and doveadm path.
+    pub fn new(command_executor: E, doveadm_path: impl Into<PathBuf>) -> Self {
+        Self {
+            command_executor,
+            doveadm_path: doveadm_path.into(),
+            userdb_socket_path: None,
+            command_timeout_secs: DEFAULT_EXTERNAL_COMMAND_TIMEOUT_SECS,
+        }
+    }
+
+    /// Points message append operations at an explicit userdb-capable socket.
+    pub fn with_userdb_socket_path(mut self, userdb_socket_path: Option<PathBuf>) -> Self {
+        self.userdb_socket_path = userdb_socket_path;
+        self
+    }
+
+    /// Caps the external doveadm save execution.
+    pub fn with_command_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.command_timeout_secs = timeout_secs.max(1);
+        self
+    }
+}
+
+impl Default for DoveadmMessageAppendBackend<SystemCommandExecutor> {
+    fn default() -> Self {
+        Self::new(SystemCommandExecutor, "/usr/local/bin/doveadm")
+    }
+}
+
+impl<E> MessageAppendBackend for DoveadmMessageAppendBackend<E>
+where
+    E: CommandExecutor,
+{
+    fn append_message(
+        &self,
+        canonical_username: &str,
+        request: &MessageAppendRequest,
+    ) -> Result<(), MailboxBackendError> {
+        let mut args = vec!["-o".to_string(), "stats_writer_socket_path=".to_string()];
+        append_doveadm_auth_socket_override(&mut args, self.userdb_socket_path.as_ref());
+        args.extend([
+            "save".to_string(),
+            "-u".to_string(),
+            canonical_username.to_string(),
+            "-m".to_string(),
+            request.mailbox_name.clone(),
+        ]);
+
+        let execution = self
+            .command_executor
+            .run_with_stdin_bytes_timeout(
+                self.doveadm_path.to_string_lossy().as_ref(),
+                &args,
+                &request.message,
+                Duration::from_secs(self.command_timeout_secs),
+            )
+            .map_err(|error| MailboxBackendError {
+                backend: "doveadm-message-append",
+                reason: error.reason,
+            })?;
+
+        if execution.status_code != 0 {
+            return Err(MailboxBackendError {
+                backend: "doveadm-message-append",
                 reason: format!(
                     "command exited with status {}: {}",
                     execution.status_code,

--- a/src/mailbox_helper.rs
+++ b/src/mailbox_helper.rs
@@ -28,8 +28,9 @@ mod mailbox_helper_protocol;
 
 pub use self::mailbox_helper_client::{
     MailboxHelperAttachmentDownloadBackend, MailboxHelperMailboxListBackend,
-    MailboxHelperMessageListBackend, MailboxHelperMessageMoveBackend,
-    MailboxHelperMessageSearchBackend, MailboxHelperMessageViewBackend,
+    MailboxHelperMessageAppendBackend, MailboxHelperMessageListBackend,
+    MailboxHelperMessageMoveBackend, MailboxHelperMessageSearchBackend,
+    MailboxHelperMessageViewBackend,
 };
 use self::mailbox_helper_dispatch::{dispatch_helper_request, log_helper_response, HelperBackends};
 #[cfg(test)]
@@ -43,19 +44,21 @@ use crate::auth::SystemCommandExecutor;
 use crate::config::{AppConfig, AppRunMode, LogLevel};
 use crate::logging::{EventCategory, LogEvent, Logger};
 use crate::mailbox::{
-    DoveadmMailboxListBackend, DoveadmMessageListBackend, DoveadmMessageMoveBackend,
-    DoveadmMessageSearchBackend, DoveadmMessageViewBackend, MailboxBackend, MailboxBackendError,
-    MailboxEntry, MailboxListingPolicy, MessageListBackend, MessageListPolicy, MessageListRequest,
+    DoveadmMailboxListBackend, DoveadmMessageAppendBackend, DoveadmMessageListBackend,
+    DoveadmMessageMoveBackend, DoveadmMessageSearchBackend, DoveadmMessageViewBackend,
+    MailboxBackend, MailboxBackendError, MailboxEntry, MailboxListingPolicy, MessageAppendBackend,
+    MessageAppendRequest, MessageListBackend, MessageListPolicy, MessageListRequest,
     MessageMoveBackend, MessageMoveRequest, MessageSearchBackend, MessageSearchPolicy,
     MessageSearchRequest, MessageSearchResult, MessageSummary, MessageView, MessageViewBackend,
-    MessageViewPolicy, MessageViewRequest,
+    MessageViewPolicy, MessageViewRequest, DEFAULT_MESSAGE_APPEND_MAX_BYTES,
 };
 #[cfg(test)]
 use crate::mailbox::{MessageMovePolicy, MessageSearchField};
 use crate::openbsd::{apply_runtime_confinement, unix_stream_peer_uid};
 
 /// Conservative upper bound for one helper request payload.
-pub const DEFAULT_MAILBOX_HELPER_MAX_REQUEST_BYTES: usize = 4096;
+pub const DEFAULT_MAILBOX_HELPER_MAX_REQUEST_BYTES: usize =
+    (DEFAULT_MESSAGE_APPEND_MAX_BYTES / 3 * 4) + 8192;
 
 /// Conservative upper bound for one helper response payload.
 ///
@@ -158,6 +161,9 @@ pub fn run_mailbox_helper_server(config: &AppConfig, logger: &Logger) -> Result<
         let message_move_backend =
             DoveadmMessageMoveBackend::new(SystemCommandExecutor, "/usr/local/bin/doveadm")
                 .with_userdb_socket_path(config.doveadm_userdb_socket_path.clone());
+        let message_append_backend =
+            DoveadmMessageAppendBackend::new(SystemCommandExecutor, "/usr/local/bin/doveadm")
+                .with_userdb_socket_path(config.doveadm_userdb_socket_path.clone());
         let policy = MailboxHelperPolicy::default();
         let mut replay_cache = BTreeMap::<String, u64>::new();
 
@@ -181,6 +187,7 @@ pub fn run_mailbox_helper_server(config: &AppConfig, logger: &Logger) -> Result<
                         message_search_backend: &message_search_backend,
                         message_view_backend: &message_view_backend,
                         message_move_backend: &message_move_backend,
+                        message_append_backend: &message_append_backend,
                     },
                     logger,
                     &mut stream,
@@ -205,8 +212,8 @@ pub fn run_mailbox_helper_server(config: &AppConfig, logger: &Logger) -> Result<
 }
 
 #[cfg(unix)]
-fn handle_helper_client<MB, MLB, MSB, MVB, MMB>(
-    backends: HelperBackends<'_, MB, MLB, MSB, MVB, MMB>,
+fn handle_helper_client<MB, MLB, MSB, MVB, MMB, MAB>(
+    backends: HelperBackends<'_, MB, MLB, MSB, MVB, MMB, MAB>,
     logger: &Logger,
     stream: &mut UnixStream,
     policy: MailboxHelperPolicy,
@@ -218,6 +225,7 @@ fn handle_helper_client<MB, MLB, MSB, MVB, MMB>(
     MSB: MessageSearchBackend,
     MVB: MessageViewBackend,
     MMB: MessageMoveBackend,
+    MAB: MessageAppendBackend,
 {
     configure_stream_timeouts(stream, policy);
 
@@ -582,6 +590,16 @@ mod tests {
         }
     }
 
+    impl MessageAppendBackend for StaticHelperBackend {
+        fn append_message(
+            &self,
+            _canonical_username: &str,
+            _request: &MessageAppendRequest,
+        ) -> Result<(), MailboxBackendError> {
+            Ok(())
+        }
+    }
+
     fn sign_test_request(request: &mut MailboxHelperRequest) -> String {
         let key = test_helper_grant_key();
         let nonce = test_grant_nonce(0);
@@ -605,6 +623,28 @@ mod tests {
         )
         .expect("test request grant should sign");
         encode_request(&request)
+    }
+
+    #[test]
+    fn message_append_grant_binds_mailbox_and_message_digest() {
+        let mut request = MailboxHelperRequest::MessageAppend {
+            canonical_username: "alice@example.com".to_string(),
+            mailbox_name: "Sent".to_string(),
+            message: b"Subject: original\r\n\r\nBody\r\n".to_vec(),
+            grant: MailboxHelperGrant::unsigned(),
+        };
+        let key = test_helper_grant_key();
+        issue_request_grant_with_nonce(&mut request, &key, 100, &test_grant_nonce(32))
+            .expect("append request should sign");
+
+        verify_request_grant(&request, &key, 100).expect("original append request should verify");
+
+        if let MailboxHelperRequest::MessageAppend { message, .. } = &mut request {
+            message.extend_from_slice(b"tampered");
+        }
+        let error = verify_request_grant(&request, &key, 100)
+            .expect_err("message mutation must invalidate the grant");
+        assert_eq!(error, "helper request grant signature was invalid");
     }
 
     #[test]
@@ -1838,6 +1878,43 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[test]
+    fn client_appends_message_over_helper_socket() {
+        let socket_path = temp_socket_path("message-append-helper-ok");
+        let backend = StaticHelperBackend {
+            mailbox_result: Arc::new(Ok(Vec::new())),
+            message_list_result: Arc::new(Ok(Vec::new())),
+            message_search_result: Arc::new(Ok(Vec::new())),
+            message_view_result: Arc::new(Err(MailboxBackendError {
+                backend: "message-view-not-used",
+                reason: "unexpected message-view request".to_string(),
+            })),
+            message_move_result: Arc::new(Ok(())),
+        };
+        let server = spawn_test_helper(socket_path.clone(), backend);
+        wait_for_socket(&socket_path);
+        let grant_key_path = temp_grant_key_path("message-append-helper-ok");
+        let client = MailboxHelperMessageAppendBackend::new(
+            &socket_path,
+            &grant_key_path,
+            MailboxHelperPolicy::default(),
+        );
+        let request = MessageAppendRequest::new(
+            "Sent",
+            b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nHello\r\n".to_vec(),
+        )
+        .expect("request should parse");
+
+        client
+            .append_message("alice@example.com", &request)
+            .expect("helper-backed message append should succeed");
+
+        server.join().expect("helper thread should finish");
+        let _ = fs::remove_file(&socket_path);
+        let _ = fs::remove_file(&grant_key_path);
+    }
+
+    #[cfg(unix)]
     fn spawn_test_helper<B>(socket_path: PathBuf, backend: B) -> thread::JoinHandle<()>
     where
         B: MailboxBackend
@@ -1845,6 +1922,7 @@ mod tests {
             + MessageSearchBackend
             + MessageViewBackend
             + MessageMoveBackend
+            + MessageAppendBackend
             + Send
             + 'static,
     {
@@ -1863,6 +1941,7 @@ mod tests {
             + MessageSearchBackend
             + MessageViewBackend
             + MessageMoveBackend
+            + MessageAppendBackend
             + Send
             + 'static,
     {
@@ -1879,6 +1958,7 @@ mod tests {
                     message_search_backend: &backend,
                     message_view_backend: &backend,
                     message_move_backend: &backend,
+                    message_append_backend: &backend,
                 },
                 &logger,
                 &mut stream,

--- a/src/mailbox_helper_client.rs
+++ b/src/mailbox_helper_client.rs
@@ -128,6 +128,11 @@ impl MailboxBackend for MailboxHelperMailboxListBackend {
                     reason: "helper returned message-move response for mailbox-list request"
                         .to_string(),
                 }),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned message-append response for mailbox-list request"
+                        .to_string(),
+                }),
             }
         }
     }
@@ -276,6 +281,11 @@ impl MessageListBackend for MailboxHelperMessageListBackend {
                 MailboxHelperResponse::MessageMoveOk { .. } => Err(MailboxBackendError {
                     backend: "mailbox-helper-client",
                     reason: "helper returned message-move response for message-list request"
+                        .to_string(),
+                }),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned message-append response for message-list request"
                         .to_string(),
                 }),
             }
@@ -451,6 +461,11 @@ impl MessageSearchBackend for MailboxHelperMessageSearchBackend {
                     reason: "helper returned message-move response for message-search request"
                         .to_string(),
                 }),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned message-append response for message-search request"
+                        .to_string(),
+                }),
             }
         }
     }
@@ -608,6 +623,11 @@ impl MessageViewBackend for MailboxHelperMessageViewBackend {
                     reason: "helper returned message-move response for message-view request"
                         .to_string(),
                 }),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned message-append response for message-view request"
+                        .to_string(),
+                }),
             }
         }
     }
@@ -737,6 +757,10 @@ impl MailboxHelperAttachmentDownloadBackend {
                 )),
                 MailboxHelperResponse::MessageMoveOk { .. } => Err(transport_error(
                     "helper returned message-move response for attachment-download request"
+                        .to_string(),
+                )),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(transport_error(
+                    "helper returned message-append response for attachment-download request"
                         .to_string(),
                 )),
             }
@@ -904,6 +928,141 @@ impl MessageMoveBackend for MailboxHelperMessageMoveBackend {
                 MailboxHelperResponse::AttachmentDownloadOk { .. } => Err(MailboxBackendError {
                     backend: "mailbox-helper-client",
                     reason: "helper returned attachment-download response for message-move request"
+                        .to_string(),
+                }),
+                MailboxHelperResponse::MessageAppendOk { .. } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned message-append response for message-move request"
+                        .to_string(),
+                }),
+            }
+        }
+    }
+}
+
+/// Client backend that proxies one-message append through the local helper socket.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MailboxHelperMessageAppendBackend {
+    socket_path: PathBuf,
+    grant_key_path: PathBuf,
+    policy: MailboxHelperPolicy,
+}
+
+impl MailboxHelperMessageAppendBackend {
+    /// Creates a message-append client backend for the supplied helper socket.
+    pub fn new(
+        socket_path: impl Into<PathBuf>,
+        grant_key_path: impl Into<PathBuf>,
+        policy: MailboxHelperPolicy,
+    ) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            grant_key_path: grant_key_path.into(),
+            policy,
+        }
+    }
+}
+
+impl MessageAppendBackend for MailboxHelperMessageAppendBackend {
+    fn append_message(
+        &self,
+        canonical_username: &str,
+        request: &MessageAppendRequest,
+    ) -> Result<(), MailboxBackendError> {
+        let mut helper_request = MailboxHelperRequest::MessageAppend {
+            canonical_username: canonical_username.to_string(),
+            mailbox_name: request.mailbox_name.clone(),
+            message: request.message.clone(),
+            grant: MailboxHelperGrant::unsigned(),
+        };
+        let request_bytes = encode_authorized_request(&self.grant_key_path, &mut helper_request);
+
+        #[cfg(not(unix))]
+        {
+            let _ = request_bytes;
+            return Err(MailboxBackendError {
+                backend: "mailbox-helper-client",
+                reason: "mailbox helper requires a Unix-domain socket platform".to_string(),
+            });
+        }
+
+        #[cfg(unix)]
+        {
+            let request_bytes = request_bytes.map_err(|reason| MailboxBackendError {
+                backend: "mailbox-helper-client",
+                reason,
+            })?;
+            let mut stream =
+                UnixStream::connect(&self.socket_path).map_err(|error| MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!(
+                        "failed to connect to mailbox helper {}: {error}",
+                        self.socket_path.display()
+                    ),
+                })?;
+
+            configure_stream_timeouts(&stream, self.policy);
+            stream
+                .write_all(&request_bytes)
+                .map_err(|error| MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!("failed to write helper request: {error}"),
+                })?;
+            stream
+                .shutdown(Shutdown::Write)
+                .map_err(|error| MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!("failed to finish helper request: {error}"),
+                })?;
+
+            let response_bytes =
+                read_bounded_from_stream(&mut stream, self.policy.max_response_bytes).map_err(
+                    |reason| MailboxBackendError {
+                        backend: "mailbox-helper-client",
+                        reason,
+                    },
+                )?;
+            let response = parse_response(
+                MailboxListingPolicy::default(),
+                MessageListPolicy::default(),
+                MessageSearchPolicy::default(),
+                MessageViewPolicy::default(),
+                std::str::from_utf8(&response_bytes).map_err(|error| MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!("helper response was not valid UTF-8: {error}"),
+                })?,
+            )
+            .map_err(|reason| MailboxBackendError {
+                backend: "mailbox-helper-client",
+                reason,
+            })?;
+
+            match response {
+                MailboxHelperResponse::MessageAppendOk {
+                    mailbox_name,
+                    message_bytes,
+                } if mailbox_name == request.mailbox_name
+                    && message_bytes == request.message.len() =>
+                {
+                    Ok(())
+                }
+                MailboxHelperResponse::MessageAppendOk {
+                    mailbox_name,
+                    message_bytes,
+                } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!(
+                        "helper append response mismatch: mailbox {:?}, bytes {}",
+                        mailbox_name, message_bytes
+                    ),
+                }),
+                MailboxHelperResponse::Error { backend, reason } => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: format!("{backend}: {reason}"),
+                }),
+                _ => Err(MailboxBackendError {
+                    backend: "mailbox-helper-client",
+                    reason: "helper returned the wrong response for message-append request"
                         .to_string(),
                 }),
             }

--- a/src/mailbox_helper_dispatch.rs
+++ b/src/mailbox_helper_dispatch.rs
@@ -6,26 +6,28 @@ use crate::config::LogLevel;
 use crate::logging::{EventCategory, LogEvent, Logger};
 #[cfg(unix)]
 use crate::mailbox::{
-    MailboxBackend, MessageListBackend, MessageListPolicy, MessageListRequest, MessageMoveBackend,
-    MessageMovePolicy, MessageMoveRequest, MessageSearchBackend, MessageSearchPolicy,
-    MessageSearchRequest, MessageViewBackend, MessageViewPolicy, MessageViewRequest,
+    MailboxBackend, MessageAppendBackend, MessageAppendRequest, MessageListBackend,
+    MessageListPolicy, MessageListRequest, MessageMoveBackend, MessageMovePolicy,
+    MessageMoveRequest, MessageSearchBackend, MessageSearchPolicy, MessageSearchRequest,
+    MessageViewBackend, MessageViewPolicy, MessageViewRequest,
 };
 
 #[cfg(unix)]
 use super::{MailboxHelperRequest, MailboxHelperResponse};
 
 #[cfg(unix)]
-pub(super) struct HelperBackends<'a, MB, MLB, MSB, MVB, MMB> {
+pub(super) struct HelperBackends<'a, MB, MLB, MSB, MVB, MMB, MAB> {
     pub(super) mailbox_backend: &'a MB,
     pub(super) message_list_backend: &'a MLB,
     pub(super) message_search_backend: &'a MSB,
     pub(super) message_view_backend: &'a MVB,
     pub(super) message_move_backend: &'a MMB,
+    pub(super) message_append_backend: &'a MAB,
 }
 
 #[cfg(unix)]
-pub(super) fn dispatch_helper_request<MB, MLB, MSB, MVB, MMB>(
-    backends: HelperBackends<'_, MB, MLB, MSB, MVB, MMB>,
+pub(super) fn dispatch_helper_request<MB, MLB, MSB, MVB, MMB, MAB>(
+    backends: HelperBackends<'_, MB, MLB, MSB, MVB, MMB, MAB>,
     request: &MailboxHelperRequest,
 ) -> MailboxHelperResponse
 where
@@ -34,6 +36,7 @@ where
     MSB: MessageSearchBackend,
     MVB: MessageViewBackend,
     MMB: MessageMoveBackend,
+    MAB: MessageAppendBackend,
 {
     match request {
         MailboxHelperRequest::MailboxList {
@@ -202,6 +205,33 @@ where
                 Err(error_response) => error_response,
             }
         }
+        MailboxHelperRequest::MessageAppend {
+            canonical_username,
+            mailbox_name,
+            message,
+            ..
+        } => {
+            match MessageAppendRequest::new(mailbox_name.clone(), message.clone())
+                .map_err(|error| MailboxHelperResponse::Error {
+                    backend: error.backend.to_string(),
+                    reason: error.reason,
+                })
+                .and_then(|request| {
+                    backends
+                        .message_append_backend
+                        .append_message(canonical_username, &request)
+                        .map_err(|error| MailboxHelperResponse::Error {
+                            backend: error.backend.to_string(),
+                            reason: error.reason,
+                        })
+                }) {
+                Ok(()) => MailboxHelperResponse::MessageAppendOk {
+                    mailbox_name: mailbox_name.clone(),
+                    message_bytes: message.len(),
+                },
+                Err(error_response) => error_response,
+            }
+        }
     }
 }
 
@@ -324,6 +354,25 @@ pub(super) fn log_helper_response(
             .with_field("part_path", attachment.part_path.clone())
             .with_field("download_bytes", attachment.body.len().to_string()),
         ),
+        (
+            MailboxHelperResponse::MessageAppendOk {
+                mailbox_name,
+                message_bytes,
+            },
+            Some(MailboxHelperRequest::MessageAppend {
+                canonical_username, ..
+            }),
+        ) => logger.emit(
+            &LogEvent::new(
+                LogLevel::Info,
+                EventCategory::Mailbox,
+                "mailbox_helper_message_appended",
+                "mailbox helper appended one message",
+            )
+            .with_field("canonical_username", canonical_username.clone())
+            .with_field("mailbox_name", mailbox_name.clone())
+            .with_field("message_bytes", message_bytes.to_string()),
+        ),
         (MailboxHelperResponse::Error { backend, reason }, Some(request)) => logger.emit(
             &LogEvent::new(
                 LogLevel::Warn,
@@ -358,5 +407,6 @@ fn helper_operation_label(request: &MailboxHelperRequest) -> &'static str {
         MailboxHelperRequest::MessageView { .. } => "message_view",
         MailboxHelperRequest::AttachmentDownload { .. } => "attachment_download",
         MailboxHelperRequest::MessageMove { .. } => "message_move",
+        MailboxHelperRequest::MessageAppend { .. } => "message_append",
     }
 }

--- a/src/mailbox_helper_protocol.rs
+++ b/src/mailbox_helper_protocol.rs
@@ -7,15 +7,16 @@
 use std::collections::BTreeMap;
 
 use hmac::{Hmac, Mac};
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 
 use crate::attachment::{
     AttachmentDownloadPolicy, AttachmentDownloadRequest, DownloadedAttachment,
 };
 use crate::mailbox::{
-    MailboxEntry, MailboxListingPolicy, MessageListPolicy, MessageListRequest, MessageMovePolicy,
-    MessageMoveRequest, MessageSearchField, MessageSearchPolicy, MessageSearchRequest,
-    MessageSearchResult, MessageSummary, MessageView, MessageViewPolicy, MessageViewRequest,
+    MailboxEntry, MailboxListingPolicy, MessageAppendRequest, MessageListPolicy,
+    MessageListRequest, MessageMovePolicy, MessageMoveRequest, MessageSearchField,
+    MessageSearchPolicy, MessageSearchRequest, MessageSearchResult, MessageSummary, MessageView,
+    MessageViewPolicy, MessageViewRequest, DEFAULT_MESSAGE_APPEND_MAX_BYTES,
 };
 
 /// Supported helper requests for the first mailbox-read slice.
@@ -55,6 +56,12 @@ pub(super) enum MailboxHelperRequest {
         source_mailbox_name: String,
         destination_mailbox_name: String,
         uid: u64,
+        grant: MailboxHelperGrant,
+    },
+    MessageAppend {
+        canonical_username: String,
+        mailbox_name: String,
+        message: Vec<u8>,
         grant: MailboxHelperGrant,
     },
 }
@@ -105,6 +112,10 @@ pub(super) enum MailboxHelperResponse {
         source_mailbox_name: String,
         destination_mailbox_name: String,
         uid: u64,
+    },
+    MessageAppendOk {
+        mailbox_name: String,
+        message_bytes: usize,
     },
     Error {
         backend: String,
@@ -181,6 +192,18 @@ pub(super) fn encode_request(request: &MailboxHelperRequest) -> String {
             encode_base64(canonical_username.as_bytes()),
             encode_base64(source_mailbox_name.as_bytes()),
             encode_base64(destination_mailbox_name.as_bytes()),
+            encode_grant_fields(grant),
+        ),
+        MailboxHelperRequest::MessageAppend {
+            canonical_username,
+            mailbox_name,
+            message,
+            grant,
+        } => format!(
+            "operation=message_append\ncanonical_username_b64={}\nmailbox_name_b64={}\nmessage_b64={}\n{}",
+            encode_base64(canonical_username.as_bytes()),
+            encode_base64(mailbox_name.as_bytes()),
+            encode_base64(message),
             encode_grant_fields(grant),
         ),
     }
@@ -325,6 +348,26 @@ pub(super) fn parse_request(input: &str) -> Result<MailboxHelperRequest, String>
                 grant,
             })
         }
+        "message_append" => {
+            let mailbox_name = decode_base64_text(
+                require_field(&fields, "mailbox_name_b64")?,
+                crate::mailbox::DEFAULT_MAILBOX_NAME_MAX_LEN,
+                "mailbox_name",
+            )?;
+            let message = decode_base64_bytes(
+                require_field(&fields, "message_b64")?,
+                DEFAULT_MESSAGE_APPEND_MAX_BYTES,
+                "message",
+            )?;
+            let request =
+                MessageAppendRequest::new(mailbox_name, message).map_err(|error| error.reason)?;
+            Ok(MailboxHelperRequest::MessageAppend {
+                canonical_username,
+                mailbox_name: request.mailbox_name,
+                message: request.message,
+                grant,
+            })
+        }
         _ => Err(format!("unsupported helper operation: {operation}")),
     }
 }
@@ -424,7 +467,8 @@ pub(super) fn request_grant(request: &MailboxHelperRequest) -> &MailboxHelperGra
         | MailboxHelperRequest::MessageSearch { grant, .. }
         | MailboxHelperRequest::MessageView { grant, .. }
         | MailboxHelperRequest::AttachmentDownload { grant, .. }
-        | MailboxHelperRequest::MessageMove { grant, .. } => grant,
+        | MailboxHelperRequest::MessageMove { grant, .. }
+        | MailboxHelperRequest::MessageAppend { grant, .. } => grant,
     }
 }
 
@@ -435,7 +479,8 @@ fn set_request_grant(request: &mut MailboxHelperRequest, new_grant: MailboxHelpe
         | MailboxHelperRequest::MessageSearch { grant, .. }
         | MailboxHelperRequest::MessageView { grant, .. }
         | MailboxHelperRequest::AttachmentDownload { grant, .. }
-        | MailboxHelperRequest::MessageMove { grant, .. } => *grant = new_grant,
+        | MailboxHelperRequest::MessageMove { grant, .. }
+        | MailboxHelperRequest::MessageAppend { grant, .. } => *grant = new_grant,
     }
 }
 
@@ -447,6 +492,7 @@ pub(super) fn helper_operation_label(request: &MailboxHelperRequest) -> &'static
         MailboxHelperRequest::MessageView { .. } => "message_view",
         MailboxHelperRequest::AttachmentDownload { .. } => "attachment_download",
         MailboxHelperRequest::MessageMove { .. } => "message_move",
+        MailboxHelperRequest::MessageAppend { .. } => "message_append",
     }
 }
 
@@ -527,6 +573,16 @@ fn canonical_grant_payload(request: &MailboxHelperRequest, grant: &MailboxHelper
             fields.push(source_mailbox_name.clone());
             fields.push(destination_mailbox_name.clone());
             fields.push(uid.to_string());
+        }
+        MailboxHelperRequest::MessageAppend {
+            canonical_username,
+            mailbox_name,
+            message,
+            ..
+        } => {
+            fields.push(canonical_username.clone());
+            fields.push(mailbox_name.clone());
+            fields.push(hex_lower(&Sha256::digest(message)));
         }
     }
     fields.join("\0")
@@ -692,6 +748,13 @@ pub(super) fn encode_response(response: &MailboxHelperResponse) -> String {
             encode_base64(source_mailbox_name.as_bytes()),
             encode_base64(destination_mailbox_name.as_bytes()),
         ),
+        MailboxHelperResponse::MessageAppendOk {
+            mailbox_name,
+            message_bytes,
+        } => format!(
+            "status=ok\noperation=message_append\nmailbox_name_b64={}\nmessage_bytes={message_bytes}\n",
+            encode_base64(mailbox_name.as_bytes()),
+        ),
         MailboxHelperResponse::Error { backend, reason } => {
             format!(
                 "status=error\nbackend_b64={}\nreason_b64={}\n",
@@ -724,6 +787,7 @@ pub(super) fn parse_response(
     let mut source_mailbox_name = None::<String>;
     let mut destination_mailbox_name = None::<String>;
     let mut moved_uid = None::<u64>;
+    let mut message_bytes = None::<usize>;
 
     for raw_line in input.lines() {
         if raw_line.is_empty() {
@@ -791,6 +855,13 @@ pub(super) fn parse_response(
                     value
                         .parse::<u64>()
                         .map_err(|error| format!("invalid helper move uid: {error}"))?,
+                )
+            }
+            "message_bytes" => {
+                message_bytes = Some(
+                    value
+                        .parse::<usize>()
+                        .map_err(|error| format!("invalid helper message byte count: {error}"))?,
                 )
             }
             "mailbox_b64" => {
@@ -888,6 +959,13 @@ pub(super) fn parse_response(
                 })?,
                 uid: moved_uid.ok_or_else(|| "helper response did not include uid".to_string())?,
             }),
+            Some("message_append") => Ok(MailboxHelperResponse::MessageAppendOk {
+                mailbox_name: mailbox_name.ok_or_else(|| {
+                    "helper response did not include append mailbox_name".to_string()
+                })?,
+                message_bytes: message_bytes
+                    .ok_or_else(|| "helper response did not include message_bytes".to_string())?,
+            }),
             Some(other) => Err(format!("unsupported helper response operation: {other}")),
             None => Err("helper response did not include an operation".to_string()),
         },
@@ -984,6 +1062,16 @@ fn reject_unknown_request_fields(
             "source_mailbox_name_b64",
             "destination_mailbox_name_b64",
             "uid",
+            "grant_issued_at",
+            "grant_expires_at",
+            "grant_nonce",
+            "grant_signature",
+        ],
+        "message_append" => &[
+            "operation",
+            "canonical_username_b64",
+            "mailbox_name_b64",
+            "message_b64",
             "grant_issued_at",
             "grant_expires_at",
             "grant_nonce",

--- a/src/mailbox_model.rs
+++ b/src/mailbox_model.rs
@@ -682,6 +682,50 @@ pub struct MessageMoveRequest {
     pub uid: u64,
 }
 
+/// Conservative maximum raw RFC 5322 message size accepted for one append.
+///
+/// This covers the current compose attachment budget after MIME base64
+/// expansion while keeping the helper mutation bounded.
+pub const DEFAULT_MESSAGE_APPEND_MAX_BYTES: usize = 48 * 1024 * 1024;
+
+/// A bounded request to append one complete message to an existing mailbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageAppendRequest {
+    pub mailbox_name: String,
+    pub message: Vec<u8>,
+}
+
+impl MessageAppendRequest {
+    /// Validates the destination mailbox and raw message size.
+    pub fn new(
+        mailbox_name: impl Into<String>,
+        message: Vec<u8>,
+    ) -> Result<Self, MailboxBackendError> {
+        let mailbox_name =
+            MailboxEntry::new(MailboxListingPolicy::default(), mailbox_name.into())?.name;
+        if message.is_empty() {
+            return Err(MailboxBackendError {
+                backend: "message-append-parser",
+                reason: "message body must not be empty".to_string(),
+            });
+        }
+        if message.len() > DEFAULT_MESSAGE_APPEND_MAX_BYTES {
+            return Err(MailboxBackendError {
+                backend: "message-append-parser",
+                reason: format!(
+                    "message body exceeded maximum length of {} bytes",
+                    DEFAULT_MESSAGE_APPEND_MAX_BYTES
+                ),
+            });
+        }
+
+        Ok(Self {
+            mailbox_name,
+            message,
+        })
+    }
+}
+
 impl MessageMoveRequest {
     /// Validates the source mailbox, destination mailbox, and UID for a
     /// one-message move operation.
@@ -923,5 +967,14 @@ pub trait MessageMoveBackend {
         &self,
         canonical_username: &str,
         request: &MessageMoveRequest,
+    ) -> Result<(), MailboxBackendError>;
+}
+
+/// A backend capable of appending one complete message to a mailbox.
+pub trait MessageAppendBackend {
+    fn append_message(
+        &self,
+        canonical_username: &str,
+        request: &MessageAppendRequest,
     ) -> Result<(), MailboxBackendError>;
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -905,7 +905,10 @@ fn describe_attachment_for_forward(attachment: &AttachmentMetadata) -> String {
 }
 
 /// Builds the RFC 5322-ish message handed to the local sendmail surface.
-fn build_submission_message(canonical_username: &str, request: &ComposeRequest) -> Vec<u8> {
+pub(crate) fn build_submission_message(
+    canonical_username: &str,
+    request: &ComposeRequest,
+) -> Vec<u8> {
     if request.attachments.is_empty() {
         return build_plain_text_submission_message(canonical_username, request).into_bytes();
     }


### PR DESCRIPTION
## Summary

This PR files successfully submitted outbound messages into the user's Sent mailbox.

## Security posture

- Delivery remains accepted through the existing sendmail path first.
- Sent filing occurs only after accepted delivery.
- The helper path appends through bounded mailbox-helper protocol authority.
- The helper grant is bound to canonical user, mailbox, and message digest.
- Sent-copy failures are logged without falsely reporting the already-accepted delivery as unsent.

## Local evidence

Before this PR was opened, the local full Rust gate completed through:

- cargo fmt --check
- cargo check --locked
- cargo test --locked --all-targets
- targeted append, helper, and send route tests
- make lint
- supply-chain check
- V7 rendering regression check
- V8 check
- security-check

## Closure requirement

This slice should not be considered closed until production evidence confirms:

- outbound delivery still works
- the submitted message appears in Sent
- osmap_mailbox_helper is healthy
- osmap_serve is healthy
- sent_copy_stored appears
- mailbox_helper_message_appended appears
- sent_copy_store_failed does not appear for the test send
