### PR TITLE
harden cargo bootstrap for security gate

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -46,6 +46,8 @@ jobs:
         env:
           OSMAP_BOOTSTRAP_CARGO_AUDIT: "1"
           OSMAP_BOOTSTRAP_CARGO_DENY: "1"
+          CARGO_HTTP_MULTIPLEXING: "false"
+          CARGO_NET_RETRY: "10"
         run: make security-check
 
   live-tls-probe:


### PR DESCRIPTION
Fixes the security-check CI failure observed on commit 9b4b0b202c5a1da6a58f31bc942cf84ff96ae15a.

The failed job passed the Rust, V4, V8, and doc-test phases, then failed while bootstrapping cargo-audit due to a Cargo HTTP/2 framing-layer transport error during crates.io access.

This change keeps the full security gate intact and adds Cargo transport resilience in the GitHub Actions security-check job by disabling Cargo HTTP/2 multiplexing and increasing Cargo network retries.

Local evidence:
- make security-check passed
- branch: fix/security-check-cargo-bootstrap-resilience-20260622
- commit: harden cargo bootstrap for security gate
- evidence archive generated under ~/Downloads