### PR TITLE
Reconcile V9 production convergence documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,28 @@ feature breadth or Roundcube parity.
 
 | Area | Status |
 |---|---|
-| Source | V8 source stabilization is complete on `main` |
+| Source | V8 source stabilization and PR #19 are complete on `main` at `49c9f23` |
 | Formal tagged release evidence | `v4.0.0`, the hostile-content safety release |
 | V5 | Boundary hardening deployed; later typed HTML source hardening is documented separately |
 | V6 | Production readiness passed; selected-cohort retirement closeout remains incomplete |
-| V7 | Findings are closed in source, but production approval remains reopened pending real-login availability proof |
-| V8 | Regression matrices and CI enforcement are complete; V8 does not claim a new production deployment |
+| V7 | Source findings and the browser availability invariant have production evidence, but V9 hold-period proof remains required before release-candidate closure |
+| V8 | Regression matrices and CI enforcement are complete; V8 does not by itself claim a new production deployment |
+| V9 | Production convergence intake is open; source, production checkout, and live binary identity are reconciled for `49c9f23`, but release-candidate status is not decided |
 
 The current release evidence is anchored by `v4.0.0`, with evidence bundle commit `59da020`
 and assessed V4 code commit `09a95b7`. V4 does not claim rich-mail safety, malware prevention, attachment preview
 safety, or URL reputation. The release rule is that any later code change must refresh V4 evidence
 before inheriting the V4 claim.
+
+V9 production convergence intake on 2026-06-22 recorded `main`, the production
+checkout, and the live OpenBSD binary converged at `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`. The deployed
+binary hash is `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`. The PR #19 deployment evidence archive
+`osmap-forward-body-binary-deploy-20260622-133538Z.tar.gz` has SHA256 `21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800` and replaced prior live
+binary hash `500cdd839be9c70297d33cbce6661815ebfb4740ba8b607f63a6cdf98ac7dca7`. The post-deployment forward/send retest reached
+OSMAP `/send` with HTTP `303` and Postfix/Brevo delivery queue `DDEA73CE8C4` was
+sent and removed. This records operational improvement, not release-candidate
+approval.
+
 
 Start with:
 
@@ -135,6 +146,7 @@ The implementation is documented as small security and workflow slices:
 | V6 | Controlled Roundcube retirement readiness | [Definition](docs/V6_DEFINITION.md), [acceptance criteria](docs/V6_ACCEPTANCE_CRITERIA.md), [roadmap](docs/V6_ROADMAP.md), [security gates](docs/V6_SECURITY_GATES.md), [closeout evidence](docs/V6_CLOSEOUT_EVIDENCE.md) |
 | V7 | Boundary hardening, rendering recovery, and availability invariants | [Due diligence](docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md), [rendering closeout](docs/V7_RENDERING_REGRESSION_CLOSEOUT.md), [browser availability invariant](docs/V7_BROWSER_AVAILABILITY_INVARIANT.md), [throttle locking](docs/POST_V7_THROTTLE_TRANSACTION_LOCKING.md) |
 | V8 | Source stabilization through mandatory regression matrices | [Program](docs/V8_STABILIZATION_PROGRAM.md), [final closeout](docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md) |
+| V9 | Production convergence and operational closure | [Production convergence](docs/V9_PRODUCTION_CONVERGENCE.md) |
 
 ### V3 assurance workstreams
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ The implementation is documented as small security and workflow slices:
 | V6 | Controlled Roundcube retirement readiness | [Definition](docs/V6_DEFINITION.md), [acceptance criteria](docs/V6_ACCEPTANCE_CRITERIA.md), [roadmap](docs/V6_ROADMAP.md), [security gates](docs/V6_SECURITY_GATES.md), [closeout evidence](docs/V6_CLOSEOUT_EVIDENCE.md) |
 | V7 | Boundary hardening, rendering recovery, and availability invariants | [Due diligence](docs/V7_BOUNDARY_HARDENING_DUE_DILIGENCE.md), [rendering closeout](docs/V7_RENDERING_REGRESSION_CLOSEOUT.md), [browser availability invariant](docs/V7_BROWSER_AVAILABILITY_INVARIANT.md), [throttle locking](docs/POST_V7_THROTTLE_TRANSACTION_LOCKING.md) |
 | V8 | Source stabilization through mandatory regression matrices | [Program](docs/V8_STABILIZATION_PROGRAM.md), [final closeout](docs/V8_FINAL_REGRESSION_GATE_CLOSEOUT.md) |
-| V9 | Production convergence and operational closure | [Production convergence](docs/V9_PRODUCTION_CONVERGENCE.md) |
 
 ### V3 assurance workstreams
 

--- a/docs/BUILD_AND_RELEASE_PROCESS.md
+++ b/docs/BUILD_AND_RELEASE_PROCESS.md
@@ -153,6 +153,39 @@ It must not be described as full V3 release validation unless the run also has
 the required host, human-prompt credential, TOTP, WSTG, pilot rehearsal, and
 sanitized evidence inputs.
 
+## V9 Production Convergence
+
+V9 is a production convergence and operational closure milestone. It is not a
+new-feature sprint and is not a release tag by itself.
+
+The V9 Slice 1 intake run on 2026-06-22 captured the following convergence
+state:
+
+- local `main`: `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`
+- remote `origin/main`: `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`
+- production checkout `/home/foo/OSMAP`: `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`
+- live binary `/usr/local/bin/osmap`: `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`
+- PR #19 deployment evidence archive: `osmap-forward-body-binary-deploy-20260622-133538Z.tar.gz`
+- PR #19 deployment evidence SHA256: `21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800`
+- V9 Slice 1 intake evidence archive: `osmap-v9-slice-1-intake-20260622-142413Z.tar.gz`
+- V9 Slice 1 intake evidence SHA256: `5de376e832ae79f8c29afd1e3b0243f8ac09a04d4bb0c71a7a771fd65403e331`
+
+This proves source and production identity convergence for the assessed
+snapshot. It does not prove release-candidate readiness.
+
+A V9 release-candidate decision still requires at least:
+
+- bounded production hold-period proof against the deployed binary;
+- V4 hostile-content carry-forward refresh on current `main`;
+- explicit V7 production availability closeout using real-login evidence;
+- explicit V6 selected-cohort/no-Roundcube closeout decision;
+- a final release gate that records unresolved limitations and rollback.
+
+Source sync must not be described as deployment. A production deployment claim
+requires source identity, rebuilt binary identity, installed live binary hash,
+service restart or continuity evidence, service health, functional operation,
+selected logs, rollback reference, archive, and checksum.
+
 ## Rollback Strategy
 
 Every release process should assume rollback may be necessary.

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -6855,3 +6855,27 @@ contained in the repository `LICENSE` file.
 Decision: current-status documents must describe the current tree and evidence.
 Historical design records may remain for provenance, but they must not override
 current operational truth.
+
+## 2026-06-22, Start V9 production convergence and record PR #19 deployment evidence
+
+V9 begins as a production convergence and operational closure milestone rather
+than a feature sprint. The immediate problem is drift between source,
+production, evidence, and documentation after V6, V7, V8, and the PR #19
+forward/send production fix.
+
+The first V9 intake evidence records local `main`, remote `origin/main`, the
+production checkout, and the live OpenBSD binary reconciled at
+`49c9f230d7865f01deadbc6a5a0f6e876c63e89b`. The live binary SHA256 is `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`. The PR #19 production
+deployment evidence archive `osmap-forward-body-binary-deploy-20260622-133538Z.tar.gz` has SHA256
+`21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800`.
+
+The post-deployment forward/send retest reached OSMAP `/send` with HTTP `303`,
+and Postfix/Brevo delivery queue `DDEA73CE8C4` completed with `status=sent` and
+was removed. The observed `breaking line > 998 bytes with <CR><LF>SPACE` line
+is recorded as transport line folding, not a delivery failure.
+
+Decision: source sync must not be treated as deployment. V9 may record the
+current production convergence state, but release-candidate status remains
+undecided until hold-period proof, V4 hostile-content carry-forward refresh,
+V7 production availability closeout, V6 selected-cohort closeout decision, and
+a final release-candidate gate are complete.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -226,3 +226,23 @@ The primary V6 gaps at the definition baseline are:
 V6 does not close or relax the broader limitations around general webmail
 parity, remote content, attachment preview, groupware, broad administration,
 OpenPGP, ManageSieve UI, or a complete denial-of-service strategy.
+
+## Version 9 Production Convergence Boundary
+
+V9 Slice 1 reconciled source and production identity after PR #19. The evidence
+shows the local checkout, `origin/main`, the production checkout, and the live
+OpenBSD binary are aligned to `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`, with live binary SHA256
+`411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`.
+
+This reduces source, production, and evidence drift but does not remove the
+remaining release limitations:
+
+- the current V4 hostile-content containment claim still needs refresh on the
+  current post-V4 codebase before inheritance is claimed;
+- V6 selected-cohort/no-Roundcube closeout remains incomplete until the selected
+  live reports and no-fallback rehearsal support it;
+- V7 browser availability has production evidence, but V9 still requires a
+  bounded hold-period proof against the deployed binary before release-candidate
+  closure;
+- V9 has not yet produced a PASS, CONDITIONAL PASS, or FAIL release-candidate
+  decision.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,8 @@ The repository deliberately separates:
 - Agent-facing collaboration guidance in the tracked repository root file
   `AGENTS.md`
 
-As of June 20, 2026, the project has substantive public-safe documentation
-through the Version 8 source-level stabilization close-out. The current
+As of June 22, 2026, the project has substantive public-safe documentation
+through the Version 9 production convergence intake. The current
 baseline was built from:
 
 - private early project planning notes, distilled into public-safe docs
@@ -35,6 +35,8 @@ baseline was built from:
   rollback, and production-validation record
 - repo-owned Version 8 stabilization program, regression matrices, executable
   gates, CI enforcement, and external evidence archives
+- repo-owned Version 9 production convergence intake, PR #19 deployment
+  evidence references, and explicit release-candidate gaps
 
 The documents in this folder are written for two audiences:
 
@@ -76,6 +78,7 @@ Current public documentation map:
 - `V8_SESSION_INTEGRITY_MATRIX.md`
 - `V8_RESOURCE_ROBUSTNESS_MATRIX.md`
 - `V8_FINAL_REGRESSION_GATE_CLOSEOUT.md`
+- `V9_PRODUCTION_CONVERGENCE.md`
 - `CRITICAL_REVIEW_HARDENING_SPRINT_2026_06_22.md`
 - `BUILD_AND_RELEASE_PROCESS.md`
 - `IMPLEMENTATION_PLAN.md`
@@ -187,13 +190,14 @@ rendering, malware prevention, or Roundcube parity. Version 5 records deployed
 identity, Host/origin, and response-boundary hardening without changing those
 product-scope limits. Version 6 defines controlled Roundcube retirement
 readiness for a selected cohort and remains incomplete until its sanitized
-live-evidence and closeout gates pass. Version 7 remains reopened for
-production because browser availability and real-login hold evidence are still
-required. Version 8 adds source-level regression coverage and mandatory CI
-enforcement, but does not deploy a new production binary or close V7.
-Requested additional functionality and Thunderbird-like UX polish remain
-future-version work unless a later definition explicitly brings them into
-scope.
+live-evidence and closeout gates pass. Version 7 browser availability has
+production evidence, but V9 still requires a bounded hold-period proof before
+release-candidate closure. Version 8 adds source-level regression coverage and
+mandatory CI enforcement. Version 9 reconciles source, production checkout,
+live binary identity, PR #19 deployment evidence, and remaining operational
+closure gaps. Requested additional functionality and Thunderbird-like UX polish
+remain future-version work unless a later definition explicitly brings them
+into scope.
 
 Some later-phase or deferred documents remain placeholders so the intended
 documentation map is visible without publishing private notes prematurely.

--- a/docs/V9_PRODUCTION_CONVERGENCE.md
+++ b/docs/V9_PRODUCTION_CONVERGENCE.md
@@ -1,0 +1,108 @@
+# V9 Production Convergence and Operational Closure
+
+## Purpose
+
+V9 exists to remove drift between source, production, evidence, and
+documentation after V6, V7, V8, and the PR #19 forward/send production fix.
+
+V9 is not a new-feature sprint and does not pursue Roundcube feature parity.
+Its purpose is to decide whether the current OSMAP state can make a defensible
+release-candidate claim.
+
+## Assessed convergence point
+
+| Item | Value |
+|---|---|
+| Assessed commit | `49c9f230d7865f01deadbc6a5a0f6e876c63e89b` |
+| Short commit | `49c9f23` |
+| Commit title | `bound forwarded compose body size` |
+| Production source path | `/home/foo/OSMAP` |
+| Production binary | `/usr/local/bin/osmap` |
+| Live binary SHA256 | `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3` |
+| Prior live binary SHA256 | `500cdd839be9c70297d33cbce6661815ebfb4740ba8b607f63a6cdf98ac7dca7` |
+| Production deploy evidence archive | `osmap-forward-body-binary-deploy-20260622-133538Z.tar.gz` |
+| Production deploy evidence SHA256 | `21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800` |
+| V9 Slice 1 intake evidence archive | `osmap-v9-slice-1-intake-20260622-142413Z.tar.gz` |
+| V9 Slice 1 intake evidence SHA256 | `5de376e832ae79f8c29afd1e3b0243f8ac09a04d4bb0c71a7a771fd65403e331` |
+
+## PR #19 production fix
+
+PR #19 addressed a production-observed forward/send regression where forwarding
+an HTML-heavy message produced a compose body above the previous 64 KiB send
+validator cap.
+
+The observed failure before the fix was:
+
+```text
+category=http action=compose_request_rejected
+reason="body exceeded maximum length of 65536 bytes"
+method="POST" path="/send" status_code="400"
+```
+
+After the PR #19 deployment, the post-deployment retest recorded:
+
+```text
+category=submission action=message_submitted
+method="POST" path="/send" status_code="303"
+```
+
+Postfix/Brevo delivery evidence recorded queue `DDEA73CE8C4` with size `82299`,
+`status=sent`, and queue removal. The Postfix line-folding entry
+`breaking line > 998 bytes with <CR><LF>SPACE` is treated as transport line
+folding, not a delivery failure, because the same queue entry completed with
+`status=sent` and was removed.
+
+## Slice 1 intake result
+
+Slice 1 was read-only. It did not deploy, rebuild, restart services, edit files,
+authenticate, or send mail.
+
+The uploaded Slice 1 evidence proves:
+
+- local `/home/foo/Workspace/OSMAP` was clean on `main` at `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`;
+- `origin/main` resolved to `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`;
+- production `/home/foo/OSMAP` was clean on `main` at `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`;
+- production `origin/main` resolved to `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`;
+- live `/usr/local/bin/osmap` had SHA256 `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`;
+- `osmap_mailbox_helper` and `osmap_serve` reported `ok` through `rcctl check`;
+- the PR #19 deployment archive existed on the host with SHA256
+  `21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800`;
+- bounded OSMAP logs recorded real browser session validation, mailbox listing,
+  message listing, sanitized HTML rendering, and successful send flow after the
+  deployment;
+- the bounded crash/restart scan did not show panic, segmentation fault, core
+  dump, fatal, crash, restart, killed, out-of-memory, or OOM entries in the
+  captured window.
+
+## What V9 does not prove yet
+
+V9 Slice 1 does not prove release readiness.
+
+The remaining V9 proof items are:
+
+1. repo documentation reconciliation;
+2. production hold-period proof against the deployed binary;
+3. V4 hostile-content carry-forward refresh on current `main`;
+4. V7 production availability closeout using real-login, mailbox, and send
+   evidence;
+5. V6 selected-cohort/no-Roundcube closeout decision;
+6. final release-candidate gate and rollback record.
+
+## Bounded release language
+
+Acceptable current claim:
+
+```text
+OSMAP source, production checkout, and live OpenBSD binary identity are
+reconciled at commit 49c9f230d7865f01deadbc6a5a0f6e876c63e89b, and the PR #19 forward/send production fix has
+post-deployment send and delivery evidence.
+```
+
+Unacceptable current claim:
+
+```text
+OSMAP is release ready.
+```
+
+Release-candidate status remains undecided until the final V9 gate records a
+PASS, CONDITIONAL PASS, or FAIL decision.


### PR DESCRIPTION
## Summary

Reconciles OSMAP Version 9 production convergence documentation after the PR #19 production forward/send fix.

## Evidence captured by Slice 1 and Slice 2

- Source, production checkout, and live binary identity converged at commit `49c9f230d7865f01deadbc6a5a0f6e876c63e89b`.
- Live production binary hash recorded as `411c976cccb0687f1a6e840470584fd8921eb5469e68905e457cf3edfe0cdea3`.
- Deployment evidence archive hash recorded as `21a2d3b97808fe6bc971974ef46a42d27216f31f04cefe7cf4894c1f667a7800`.
- Post-deployment `/send` retest recorded HTTP `303`.
- Postfix/Brevo delivery evidence recorded queue `DDEA73CE8C4` sent and removed.

## Boundaries

This is documentation-only. It does not deploy, rebuild, restart services, authenticate to OSMAP, send mail, or change production.

## Remaining V9 gaps

- Production hold-period proof.
- V4 hostile-content carry-forward refresh.
- V7 production availability closeout.
- V6 selected-cohort / no-Roundcube operation closeout.
- Final V9 release-candidate gate.
