### PR TITLE
ui: add v14 css icon foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,3 +132,4 @@ v12-check:
 
 v14-check:
 	sh maint/security/osmap-v14-streamline-webui-docs-gate.sh
+	sh maint/security/osmap-v14-css-icon-foundation-gate.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -389,3 +389,7 @@ V7 production availability was previously reopened pending real-login, real-mail
 
 - `V14_STREAMLINE_WEBUI_OPENPGP_UX.md` records the V14 UI claims, design boundary, OpenPGP UX constraints, JavaScript-free runtime rule, and low-SBOM implementation rules.
 - `design/v14-approved-ui-reference/README.md` records the approved UI reference images and states that they are design references only, not runtime browser assets.
+
+## V14 Slice 2 CSS and Local Icon Foundation
+
+- `V14_SLICE_2_CSS_ICON_FOUNDATION.md` records the CSS-only and local inline SVG icon foundation for the V14 Streamline WebUI sprint.

--- a/docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md
+++ b/docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md
@@ -1,0 +1,46 @@
+# V14 Slice 2 CSS and Local Icon Foundation
+
+## Status
+
+V14 Slice 2 adds the first runtime UI foundation for the Streamline WebUI and OpenPGP UX sprint. The slice is intentionally narrow and does not change mail, authentication, OpenPGP runtime behavior, deployment posture, or production host configuration.
+
+## Scope
+
+This slice provides:
+
+- shared CSS primitives for local inline SVG icons
+- navigation hover and active-state styling for the authenticated app header
+- a local inline SVG shield mark for the OSMAP brand in the authenticated shell
+- documentation and a gate for the CSS and icon foundation
+
+The implementation remains server-rendered Rust HTML. It does not introduce JavaScript, an npm or node build chain, frontend frameworks, external CDNs, web fonts, remote images, or additional dependencies.
+
+## Security boundary
+
+The icon foundation is local template markup only. SVG paths are static, fixed strings emitted by the Rust UI helpers. No user-controlled field is inserted into SVG attributes or path data.
+
+The approved V14 images under `docs/design/v14-approved-ui-reference/` remain design references only. They are not runtime browser assets and are not permission to weaken CSP, add JavaScript, or add a frontend build pipeline.
+
+## OpenPGP UX boundary
+
+This slice does not enable OpenPGP decrypt, verify, sign, encrypt, PGP/MIME parsing, passphrase handling, private-key access, browser OpenPGP controls, key discovery, or decrypted rendering. Future OpenPGP UX slices must preserve the V12 non-cryptographic boundary until runtime crypto work is explicitly implemented and reviewed.
+
+Verified signatures do not make content safe. Decrypted content must still pass through protected rendering. Source view remains explicit, escaped, authorized, and bounded.
+
+## Validation
+
+Expected local validation for this slice:
+
+- `git diff --check`
+- `make v14-check`
+- `cargo check`
+- targeted browser/UI rendering tests
+
+GitHub Actions remains the merge gate before this slice is merged to `origin/main`.
+
+## Slice 2 no runtime script and asset boundary
+
+- CSS-only: this slice adds styling and local inline SVG structure only.
+- No JavaScript is introduced or required by this slice.
+- The local inline SVG foundation performs no runtime asset fetch.
+- Runtime UI remains server-rendered Rust HTML under the existing restrictive CSP.

--- a/docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md
+++ b/docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md
@@ -44,3 +44,7 @@ GitHub Actions remains the merge gate before this slice is merged to `origin/mai
 - No JavaScript is introduced or required by this slice.
 - The local inline SVG foundation performs no runtime asset fetch.
 - Runtime UI remains server-rendered Rust HTML under the existing restrictive CSP.
+
+## V4 hostile-route compatibility
+
+Authenticated message routes retain the V4 hostile-content zero auto-fetch-surface invariant. Slice 2 therefore keeps the authenticated app-header brand mark as inert text with the shared `ui-icon brand-icon` classes. Inline SVG remains local-only and dependency-free, but it must not be added to route-backed message views unless the hostile-route assurance model is explicitly updated with evidence.

--- a/maint/security/osmap-v14-css-icon-foundation-gate.sh
+++ b/maint/security/osmap-v14-css-icon-foundation-gate.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+failures=0
+
+fail() {
+    printf '%s\n' "FAIL: $1" >&2
+    failures=$((failures + 1))
+}
+
+require_file() {
+    if [ ! -f "$1" ]; then
+        fail "missing file: $1"
+    fi
+}
+
+require_pattern() {
+    pattern="$1"
+    file="$2"
+    if ! grep -Eq "$pattern" "$file"; then
+        fail "missing required V14 CSS/icon foundation text in $file: $pattern"
+    fi
+}
+
+reject_runtime_pattern() {
+    pattern="$1"
+    shift
+    for file in "$@"; do
+        if [ -f "$file" ] && grep -Eq "$pattern" "$file"; then
+            printf '%s\n' "disallowed V14 runtime pattern found in $file" >&2
+            grep -nE "$pattern" "$file" >&2 || true
+            failures=$((failures + 1))
+        fi
+    done
+}
+
+require_file "src/http_support.rs"
+require_file "src/http_ui.rs"
+require_file "docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md"
+require_file "maint/security/osmap-v14-css-icon-foundation-gate.sh"
+
+require_pattern "fn browser_css" "src/http_support.rs"
+require_pattern "ui-icon" "src/http_support.rs"
+require_pattern "brand-icon" "src/http_support.rs"
+require_pattern "currentColor" "src/http_support.rs"
+require_pattern "prefers-reduced-motion" "src/http_support.rs"
+require_pattern "ui-icon brand-icon" "src/http_ui.rs"
+
+require_pattern "CSS-only" "docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md"
+require_pattern "local inline SVG" "docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md"
+require_pattern "No JavaScript" "docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md"
+require_pattern "no runtime asset fetch" "docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md"
+
+reject_runtime_pattern '<script|javascript:|onload=|onclick=|cdn\.jsdelivr|unpkg\.com|cdnjs\.cloudflare|package-lock\.json|pnpm-lock\.yaml|yarn\.lock' \
+    src/http_ui.rs \
+    docs/V14_SLICE_2_CSS_ICON_FOUNDATION.md \
+    docs/README.md
+
+if [ "$failures" -ne 0 ]; then
+    printf '%s\n' "v14 css icon foundation gate failed: $failures failure(s)" >&2
+    exit 1
+fi
+
+printf '%s\n' "v14 css icon foundation gate passed"

--- a/maint/security/v10-claims-boundary.json
+++ b/maint/security/v10-claims-boundary.json
@@ -62,7 +62,7 @@
     "security_check": "preserved",
     "v10_check_target_present": true
   },
-  "generated_at_utc": "2026-06-25T10:58:50Z",
+  "generated_at_utc": "2026-06-28T17:36:55Z",
   "purpose": "Targeted fail-closed remediation for the V10 governance boundary.",
   "required_followups": [
     "Classify Rust fail-closed assumptions from Slice 0.",
@@ -84,7 +84,7 @@
     "audit_script_present": true,
     "classification_complete": true,
     "current_scanner_count": 725,
-    "inventory_sha256": "bf2ce5a364cd4a1b83affb87e35252a40ac722b99e5774bb669cfad6a6f4b402",
+    "inventory_sha256": "f770a9c9d063a919454e44e7c589069dca6c16179d09663b0442a51790073fd9",
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
@@ -118,7 +118,7 @@
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
-    "refined_inventory_sha256": "610e5a45b1ef4f3dcfa2440f51322ba1e4e550629329190e4eb2152fe1247b7e",
+    "refined_inventory_sha256": "5a297993a0305c21ccb55651324cc2d4c8aa4e28031ed9d5cb7c303357aed4a4",
     "remediation_document": "docs/V10_TARGETED_FAIL_CLOSED_REMEDIATION.md",
     "remediation_document_present": true,
     "remediation_register": "maint/security/v10-fail-closed-remediation.json",

--- a/maint/security/v10-fail-closed-remediation.json
+++ b/maint/security/v10-fail-closed-remediation.json
@@ -11,7 +11,7 @@
       "low": 76,
       "medium": 2
     },
-    "inventory_sha256": "bf2ce5a364cd4a1b83affb87e35252a40ac722b99e5774bb669cfad6a6f4b402",
+    "inventory_sha256": "f770a9c9d063a919454e44e7c589069dca6c16179d09663b0442a51790073fd9",
     "schema_version": 1,
     "slice": "V10 Slice 4",
     "source": "maint/security/v10-rust-assumption-audit.json",
@@ -23,7 +23,7 @@
     "This slice does not claim broad public release readiness.",
     "This slice does not change production deployment state."
   ],
-  "generated_at_utc": "2026-06-27T14:19:57Z",
+  "generated_at_utc": "2026-06-28T17:36:55Z",
   "purpose": "Targeted fail-closed remediation register for Rust assumption handling after the Slice 4 audit.",
   "refined_current": {
     "by_classification": {
@@ -35,7 +35,7 @@
       "medium": 1
     },
     "high_relevance_top_files": {},
-    "inventory_sha256": "610e5a45b1ef4f3dcfa2440f51322ba1e4e550629329190e4eb2152fe1247b7e",
+    "inventory_sha256": "5a297993a0305c21ccb55651324cc2d4c8aa4e28031ed9d5cb7c303357aed4a4",
     "total_count": 725
   },
   "required_followups": [

--- a/maint/security/v10-rust-assumption-audit.json
+++ b/maint/security/v10-rust-assumption-audit.json
@@ -1454,7 +1454,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_support.rs",
       "kind": "expect_call",
-      "line": 365
+      "line": 370
     },
     {
       "classification": "production_adjacent_assumption",
@@ -5801,7 +5801,7 @@
       "line": 521
     }
   ],
-  "generated_at_utc": "2026-06-27T14:19:57Z",
+  "generated_at_utc": "2026-06-28T17:36:55Z",
   "non_claims": [
     "This audit does not claim that all Rust assumptions are safe.",
     "This audit does not claim that production request paths are panic-free.",
@@ -5856,7 +5856,7 @@
       "unwrap_call": 6
     },
     "classification_complete": true,
-    "inventory_sha256": "bf2ce5a364cd4a1b83affb87e35252a40ac722b99e5774bb669cfad6a6f4b402",
+    "inventory_sha256": "f770a9c9d063a919454e44e7c589069dca6c16179d09663b0442a51790073fd9",
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,

--- a/src/http_support.rs
+++ b/src/http_support.rs
@@ -139,9 +139,13 @@ fn browser_css() -> &'static str {
         ".muted{color:var(--muted)}",
         ".page-shell{min-height:100vh;padding:1.5rem}",
         ".topbar{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin-bottom:1rem;padding:.8rem 1rem;background:var(--panel);border:1px solid var(--line);border-radius:8px}",
-        ".brand{display:flex;align-items:center;gap:.65rem;font-weight:800}",
+        ".brand{display:flex;align-items:center;gap:.65rem;font-weight:800;letter-spacing:.01em}",
+        ".ui-icon{display:inline-block;width:1rem;height:1rem;flex:0 0 auto;vertical-align:-.15em;color:currentColor}",
+        ".brand-icon{width:1.25rem;height:1.25rem}",
         ".brand-mark{display:inline-grid;place-items:center;width:2.1rem;height:2.1rem;border-radius:7px;background:#dbeafe;color:#123b7a;border:1px solid #b8cffc;font-weight:900}",
         ".top-actions,.toolbar,.status-row,.badge-list{display:flex;align-items:center;gap:.55rem;flex-wrap:wrap}",
+        ".top-actions a{display:inline-flex;align-items:center;min-height:2.15rem;padding:.42rem .58rem;border-radius:7px;color:#223047;text-decoration:none}",
+        ".top-actions a:hover,.top-actions a[aria-current=page]{background:#eaf2ff;color:#123b7a;text-decoration:none}",
         ".logout-form{display:inline-flex}",
         ".badge,.status-pill{display:inline-flex;align-items:center;gap:.35rem;border:1px solid var(--line);border-radius:999px;background:#fff;padding:.35rem .6rem;color:#223047;font-size:.86rem}",
         ".badge-ok{border-color:#b7dfc2;background:#eefaf1;color:#14532d}",
@@ -207,6 +211,7 @@ fn browser_css() -> &'static str {
         ".message-html pre,pre{white-space:pre-wrap;overflow-wrap:anywhere}",
         ".message-html a{word-break:break-word}",
         ".message-html a[href]::after{content:\" (\" attr(href) \")\";font-size:.86em;color:var(--muted);overflow-wrap:anywhere}",
+        "@media (prefers-reduced-motion:reduce){*,*::before,*::after{scroll-behavior:auto!important;transition:none!important;animation:none!important}}",
         "@media (max-width:56rem){.page-shell{padding:.75rem}.topbar,.section-header{align-items:stretch;flex-direction:column}.mail-shell,.mail-shell-three{grid-template-columns:1fr}.search-row{grid-template-columns:1fr}.login-card{padding:1.25rem}.login-title{font-size:2.35rem}.login-shield{width:3.8rem;height:3.8rem}.security-grid{grid-template-columns:1fr}.login-decor{display:none}}"
     )
 }

--- a/src/http_ui.rs
+++ b/src/http_ui.rs
@@ -84,7 +84,7 @@ fn app_header(canonical_username: &str, csrf_token: &str, current: &str) -> Stri
     format!(
         concat!(
             "<header class=\"topbar\">",
-            "<div class=\"brand\"><span class=\"brand-mark\" aria-hidden=\"true\"><svg class=\"ui-icon brand-icon\" viewBox=\"0 0 24 24\"><path d=\"M12 3 19 6v5c0 5-2.6 8.5-7 10-4.4-1.5-7-5-7-10V6l7-3Z\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.8\"/><path d=\"m9 12 2 2 4-5\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.8\"/></svg></span><span>OSMAP</span></div>",
+            "<div class=\"brand\"><span class=\"brand-mark\" aria-hidden=\"true\"><span class=\"ui-icon brand-icon\">OS</span></span><span>OSMAP</span></div>",
             "<nav class=\"top-actions\" aria-label=\"Primary\">",
             "<a href=\"/mailboxes\"{}>Mailboxes</a>",
             "<a href=\"/compose\"{}>Compose</a>",

--- a/src/http_ui.rs
+++ b/src/http_ui.rs
@@ -84,7 +84,7 @@ fn app_header(canonical_username: &str, csrf_token: &str, current: &str) -> Stri
     format!(
         concat!(
             "<header class=\"topbar\">",
-            "<div class=\"brand\"><span class=\"brand-mark\" aria-hidden=\"true\">OS</span><span>OSMAP</span></div>",
+            "<div class=\"brand\"><span class=\"brand-mark\" aria-hidden=\"true\"><svg class=\"ui-icon brand-icon\" viewBox=\"0 0 24 24\"><path d=\"M12 3 19 6v5c0 5-2.6 8.5-7 10-4.4-1.5-7-5-7-10V6l7-3Z\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.8\"/><path d=\"m9 12 2 2 4-5\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.8\"/></svg></span><span>OSMAP</span></div>",
             "<nav class=\"top-actions\" aria-label=\"Primary\">",
             "<a href=\"/mailboxes\"{}>Mailboxes</a>",
             "<a href=\"/compose\"{}>Compose</a>",


### PR DESCRIPTION
## Summary

Adds the V14 Slice 2 CSS and local icon foundation.

Scope:
- adds reusable CSS tokens for local icon styling
- keeps the authenticated app-header brand mark inert text with shared `ui-icon brand-icon` classes
- adds reduced-motion CSS handling
- documents the Slice 2 CSS-only, local-icon, and V4 hostile-route compatibility boundary
- extends v14-check with the Slice 2 CSS/icon foundation gate

Security boundary:
- no runtime JavaScript
- no frontend framework
- no npm/node/Vite/Webpack chain
- no external CDN or runtime asset fetch
- no OpenPGP runtime capability change
- no live-host, deployment, nginx, Postfix, or Dovecot change
- no route-backed SVG auto-fetch surface in hostile-message views

## Validation

Passed locally:
- git diff --check
- make v14-check
- cargo check
- cargo test html_response_accepts_typed_template_output_and_escapes_title --lib
- cargo test --test v4_hostile_assurance -- v4_hostile_content_assurance_corpus_gate

Evidence:
- V14 Slice 2 repair evidence captured with FAIL=0 and CRITICAL_FAIL=0.
- NO_RUNTIME_JAVASCRIPT=true.
- NO_NEW_DEPENDENCIES=true.
- NO_LIVE_HOST_CHECKS=true.

GitHub Actions remains the merge gate for the full security-check matrix.