### PR TITLE
security: close v15 HTTP differential policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ The project favors a small trust boundary, least privilege, bounded behavior,
 safe mail rendering, auditable operations, and reversible deployment over
 feature breadth or Roundcube parity.
 
+## Current V15 HTTP assurance status
+
+V15 Slice 04 is deployed and closes the fixed 37-case HTTP edge/origin
+differential corpus. The signed parser implementation rejects non-decimal
+`Content-Length`, bounds every header value to 8 KiB, and pairs with an nginx
+one-request-per-client-connection control. Both offline and live campaigns
+passed with zero required-policy failures, observation-only cases, or origin
+cardinality violations. The evidence and precise claim boundary are recorded
+in [V15 HTTP differential assurance](docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md).
+
+This bounded result does not claim universal HTTP parser equivalence or widen
+the project's broader production and hostile-content claims.
+
 ## Current V13 status
 
 V13 is the current reviewed production and assurance closeout. It supersedes

--- a/docs/CURRENT_PROJECT_STATUS.md
+++ b/docs/CURRENT_PROJECT_STATUS.md
@@ -141,5 +141,5 @@ version closeout document in the same change stream.
 <!-- v15-slice-03e-status:start -->
 ## Current V15 assurance status
 
-V15 Slice 03D is complete at signed commit `315534ff915f4ae3e5ba8a5778060891ccefec07`. The accepted OpenBSD production binary is `4dc1005f1e3f11ecf463fa4724a432622b7952bd378831f4c135ef3544f0f5bf`, direct-origin strict parsing and corrected TLS-edge canonicalisation acceptance passed, rollback was not required, and effective nginx, mailbox-helper, listener, and PF controls remained unchanged under their accepted evidence contracts. Slice 03E local CI status is **PASS**. See [V15_HTTP_DIFFERENTIAL_ASSURANCE.md](V15_HTTP_DIFFERENTIAL_ASSURANCE.md).
+V15 Slice 04 closes every policy in the fixed 37-case HTTP differential corpus. The signed implementation commit is `158f61d3735712faac019cae97f7ef3e26787973`, the assessed policy/harness commit is `6e28ae4ed8b83584ba5df1e522e17b358e5e8ebd`, and the deployed OpenBSD binary SHA-256 is `d7426c8b51bed05f535da7195246a04365c3c5f39967a0170e64f350761cc85e`. Offline and live campaigns both report 37 cases, zero required-policy failures, zero measured cases, and zero cardinality violations. Historical Slice 03 conclusions and evidence remain accepted. See [V15_HTTP_DIFFERENTIAL_ASSURANCE.md](V15_HTTP_DIFFERENTIAL_ASSURANCE.md).
 <!-- v15-slice-03e-status:end -->

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -6977,3 +6977,29 @@ only. It does not change runtime UI behavior, deployment state, OpenPGP runtime
 capability, production configuration, live-host posture, or current V13
 production evidence. V13 remains the current reviewed production and assurance
 closeout until a later V14 closeout explicitly supersedes it.
+
+## 2026-08-16, Close V15 HTTP differential policies
+
+Decision: close all observation-only policies in the fixed 37-case corpus and
+enforce explicit origin, edge, semantic-shape, and forwarding-cardinality
+outcomes.
+
+The origin retains its narrow field-name policy, requires ASCII decimal digits
+for `Content-Length`, and limits each header value to 8 KiB. The OSMAP nginx
+locations close client connections after one response, preventing a pipelined
+second request from becoming another origin request. A conditional forensic
+log is active only for bounded `OSMAPS04-*` tokens; ordinary browser queries
+remain excluded.
+
+Evidence: implementation `158f61d3735712faac019cae97f7ef3e26787973`,
+assessed policy/harness `6e28ae4ed8b83584ba5df1e522e17b358e5e8ebd`,
+deployed binary SHA-256
+`d7426c8b51bed05f535da7195246a04365c3c5f39967a0170e64f350761cc85e`,
+and evidence archive SHA-256
+`de1a823e21c7a5014ec840c132d9e77b5759b03186727947f51cd5947d16fb6d`.
+Offline and live campaigns each passed 37 cases with zero policy failures,
+measured cases, or cardinality violations.
+
+Boundary: preserve all Slice 03 conclusions and raw evidence. This decision is
+limited to the accepted corpus and edge configuration and does not claim
+universal HTTP parser equivalence.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -28,6 +28,10 @@
 - The current HTTP runtime now has clearer connection-pressure, write-failure,
   and accept-failure observability, but it still depends on adjacent controls
   and does not yet provide a complete request-resource exhaustion strategy
+- V15 closes every required policy in a fixed 37-case HTTP edge/origin corpus,
+  including forwarding cardinality and selected canonicalization behavior. It
+  does not claim universal equivalence across every HTTP client, intermediary,
+  protocol version, nginx release, or request grammar.
 - Runtime auth, mailbox, and sendmail command execution now has a shared
   timeout-enforced executor with a bounded environment and explicit stdout and
   stderr byte caps. It still depends on the synchronous request model, so very

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,7 +207,8 @@ Current public documentation map:
 - `V14_STREAMLINE_WEBUI_OPENPGP_UX.md`
 - `V14_SLICE_10_ACCESSIBILITY_RESPONSIVE_PASS.md`
 - `V14_FINAL_REGRESSION_EVIDENCE_CLOSEOUT.md`
-- `V15_HTTP_DIFFERENTIAL_ASSURANCE.md`
+- `V15_HTTP_DIFFERENTIAL_ASSURANCE.md` — fixed-corpus parser, forwarding,
+  deployment, and Slice 04 policy-closure evidence
 - `CURRENT_PROJECT_STATUS.md`
 
 - `V9_RELEASE_CANDIDATE_CLOSEOUT.md`

--- a/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
+++ b/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
@@ -71,10 +71,12 @@ The corpus covers:
 - request-line, field, and header-block limits
 
 Every case now has an enforceable policy. `REJECT_BEFORE_ORIGIN` requires zero
-origin requests and a rejecting edge outcome. `FORWARD_EXACTLY_ONE` requires
-one response and one origin request with the same method, complete target, and
-authority. `CANONICALIZE_EXACTLY_ONE` permits only syntax canonicalization or
-discarding an unused field while preserving that same semantic shape.
+origin requests and a rejecting edge outcome. `REJECT_OR_FORWARD_ONCE` permits
+the edge either to reject directly or to forward one unchanged semantic shape
+to the strict origin for rejection. `FORWARD_EXACTLY_ONE` requires one response
+and one origin request with the same method, complete target, and authority.
+`CANONICALIZE_EXACTLY_ONE` permits only syntax canonicalization or discarding
+unused bytes or fields while preserving that same semantic shape.
 
 The six former observation-only cases are closed as follows:
 
@@ -91,6 +93,9 @@ The three previously accepted request-syntax normalizations use
 `CANONICALIZE_EXACTLY_ONE`. The pipelining case uses
 `FORWARD_EXACTLY_ONE`: nginx must close the client connection after the first
 response, preventing queued bytes from becoming another origin request.
+Unambiguous chunked framing and non-message trailing bytes may likewise be
+canonicalized only into one equivalent origin request; every other hostile
+case must be rejected at the edge or by one strict origin request.
 
 ## Evidence Handling
 

--- a/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
+++ b/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
@@ -235,3 +235,47 @@ Effective nginx configuration, mailbox-helper state, OSMAP listener exposure, an
 
 Slice 03D status: **COMPLETE**. Slice 03E is a nonfunctional closeout and protected-integration slice. It introduces no JavaScript, Node.js, npm, frontend framework, external CDN, production Rust behaviour, or new dependency.
 <!-- slice-03e-closeout:end -->
+
+<!-- slice-04-closeout:start -->
+## V15 Slice 04 policy closure
+
+Slice 04 is complete for the fixed 37-case HTTP edge/origin corpus.
+
+| Item | Accepted value |
+|---|---|
+| Implementation commit | `158f61d3735712faac019cae97f7ef3e26787973` |
+| Assessed policy and harness commit | `6e28ae4ed8b83584ba5df1e522e17b358e5e8ebd` |
+| Signing fingerprint | `F55E404E91A0753701F91B01A7228D3FB5084B34` |
+| Deployed release binary SHA-256 | `d7426c8b51bed05f535da7195246a04365c3c5f39967a0170e64f350761cc85e` |
+| Evidence archive | `osmap-v15-slice04-evidence-6e28ae4.tar.gz` |
+| Evidence archive SHA-256 | `de1a823e21c7a5014ec840c132d9e77b5759b03186727947f51cd5947d16fb6d` |
+| Previous binary rollback SHA-256 | `4dc1005f1e3f11ecf463fa4724a432622b7952bd378831f4c135ef3544f0f5bf` |
+
+The archive's internal manifest verified every file. It preserves exact
+base64-encoded corpus requests, raw edge and direct-origin responses, response
+and connection observations, token-correlated forwarding logs, application
+outcomes, signed commit identities, deployment diffs, and service state.
+
+Both the offline and live required-policy campaigns passed:
+
+```text
+case_count=37
+required_policy_failures=0
+measured_unique_cases=0
+origin_request_cardinality_violations=0
+```
+
+The parser now rejects non-ASCII-decimal `Content-Length` values and enforces
+an 8 KiB generic header-value limit. nginx closes OSMAP client connections
+after one response, so the pipelined second request no longer reaches the
+origin. The conditional test log does not record normal browser query strings.
+
+The deployed services remained healthy after the bounded binary installation,
+nginx configuration validation, OSMAP restart, and nginx reload. Rollback
+copies and an executable restore procedure remain under the host-side Slice 04
+deployment sessions.
+
+The historical Slice 03 evidence and conclusions above remain unchanged.
+Slice 04 does not claim universal HTTP parser equivalence beyond the fixed
+corpus and accepted edge configuration.
+<!-- slice-04-closeout:end -->

--- a/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
+++ b/docs/V15_HTTP_DIFFERENTIAL_ASSURANCE.md
@@ -13,6 +13,8 @@ The V15 differential harness preserves the exact request bytes and records:
 - raw direct-origin response over the OpenBSD loopback listener
 - nginx and OSMAP log lines containing the per-case run token
 - the required strict origin policy and edge policy for every corpus case
+- token-correlated edge interpretation and origin forwarding count
+- the application response separately from parser and forwarding decisions
 
 ## Repository Components
 
@@ -68,8 +70,27 @@ The corpus covers:
 - request-target normalization
 - request-line, field, and header-block limits
 
-Cases explicitly marked `MEASURE` are retained as evidence until the edge
-and origin policy is reviewed. They are not silently converted to PASS.
+Every case now has an enforceable policy. `REJECT_BEFORE_ORIGIN` requires zero
+origin requests and a rejecting edge outcome. `FORWARD_EXACTLY_ONE` requires
+one response and one origin request with the same method, complete target, and
+authority. `CANONICALIZE_EXACTLY_ONE` permits only syntax canonicalization or
+discarding an unused field while preserving that same semantic shape.
+
+The six former observation-only cases are closed as follows:
+
+| Case | Origin | Edge |
+|---|---|---|
+| `valid_post_content_length_zero` | accept | forward exactly one; record the route status separately |
+| `underscore_field_name` | reject under OSMAP's narrow field-name allowlist | discard the unused field and canonicalize exactly one equivalent request |
+| `dot_in_field_name` | reject under OSMAP's narrow field-name allowlist | discard the unused field and canonicalize exactly one equivalent request |
+| `comma_content_length_same` | reject strict framing | reject before origin |
+| `malformed_content_length_plus` | reject non-digit Content-Length | reject before origin |
+| `oversized_header_field` | reject above the 8 KiB value limit | reject before origin |
+
+The three previously accepted request-syntax normalizations use
+`CANONICALIZE_EXACTLY_ONE`. The pipelining case uses
+`FORWARD_EXACTLY_ONE`: nginx must close the client connection after the first
+response, preventing queued bytes from becoming another origin request.
 
 ## Evidence Handling
 
@@ -78,12 +99,26 @@ They contain no credentials or session material. The live bundle must keep
 the host log capture and JSON result together with the SHA-256 evidence
 manifest.
 
+Normal public access logs continue to omit query strings. A separate
+conditional log records the complete target and upstream outcome only when the
+request contains a bounded `OSMAPS04-*` differential token. This makes live
+forwarding cardinality deterministic without exposing normal browser queries.
+
 ## Acceptance Boundary
 
-The harness implementation can be accepted when its self-tests, offline
-inventory, and normal OSMAP gates pass. Parser conformance is accepted only
-after a separate live campaign runs the complete corpus with required-policy
-enforcement.
+Acceptance requires the complete offline and live campaigns to report:
+
+```text
+case_count=37
+required_policy_failures=0
+measured_unique_cases=0
+origin_request_cardinality_violations=0
+```
+
+Parser conformance is accepted only after the live campaign runs the complete
+corpus with required-policy enforcement. The isolated nginx regression test
+also proves that a pipelined second request is not forwarded while a new client
+connection remains usable.
 
 <!-- slice-03e-closeout:start -->
 # OSMAP V15 request-line parser assurance closeout

--- a/maint/openbsd/mail.blackbagsecurity.com/README.md
+++ b/maint/openbsd/mail.blackbagsecurity.com/README.md
@@ -33,6 +33,10 @@ the private/control listeners:
 - the public access log records normalized paths without query strings,
   referrers, cookies, or client-supplied forwarding chains
 - public OSMAP logs are retained as `root:wheel` mode `0640`
+- a conditional differential log records method, complete test target,
+  authority, and upstream outcome only for bounded `OSMAPS04-*` corpus tokens
+- OSMAP locations close the client connection after one response so queued
+  pipelined bytes cannot create a second origin request
 - public requests have conservative per-source request and connection limits;
   application throttling remains authoritative for authentication decisions
 

--- a/maint/openbsd/mail.blackbagsecurity.com/newsyslog/osmap-public.conf
+++ b/maint/openbsd/mail.blackbagsecurity.com/newsyslog/osmap-public.conf
@@ -1,2 +1,3 @@
 /var/log/nginx/osmap.public.access.log root:wheel 640 14 50000 * Z /var/run/nginx.pid "kill -USR1 $(cat /var/run/nginx.pid) >/dev/null 2>&1 || true"
 /var/log/nginx/osmap.public.error.log  root:wheel 640 14 20000 * Z /var/run/nginx.pid "kill -USR1 $(cat /var/run/nginx.pid) >/dev/null 2>&1 || true"
+/var/log/nginx/osmap.differential.access.log root:wheel 640 14 20000 * Z /var/run/nginx.pid "kill -USR1 $(cat /var/run/nginx.pid) >/dev/null 2>&1 || true"

--- a/maint/openbsd/mail.blackbagsecurity.com/nginx/conf-enabled/10-osmap-public-edge.conf
+++ b/maint/openbsd/mail.blackbagsecurity.com/nginx/conf-enabled/10-osmap-public-edge.conf
@@ -9,6 +9,19 @@ log_format osmap_public_security
     'upstream_status="$upstream_status" '
     'request_time="$request_time" upstream_time="$upstream_response_time"';
 
+# A test-only correlation stream records the complete target only for bounded
+# V15 differential tokens. Normal browser requests never enter this log, so
+# the public log continues to omit query strings and other sensitive fields.
+map $request $osmap_differential_loggable {
+    default 0;
+    ~OSMAPS04-[A-Za-z0-9_-]+ 1;
+}
+
+log_format osmap_differential_security
+    'token="$arg_osmap_s03" request="$request" method="$request_method" '
+    'request_uri="$request_uri" host="$host" status="$status" '
+    'upstream_addr="$upstream_addr" upstream_status="$upstream_status"';
+
 # Conservative per-source resource protection. Application login throttling
 # remains authoritative for authentication decisions.
 limit_req_zone $binary_remote_addr zone=osmap_public_general:1m rate=10r/s;

--- a/maint/openbsd/mail.blackbagsecurity.com/nginx/templates/osmap-public-root.tmpl
+++ b/maint/openbsd/mail.blackbagsecurity.com/nginx/templates/osmap-public-root.tmpl
@@ -12,6 +12,14 @@ location = /login {
     limit_req zone=osmap_public_login burst=6 nodelay;
     limit_conn osmap_public_connections 10;
 
+    # One client connection may submit only one OSMAP request. Closing after
+    # the response prevents queued pipelined bytes from becoming a second
+    # origin request.
+    keepalive_timeout 0;
+
+    access_log /var/log/nginx/osmap.public.access.log osmap_public_security;
+    access_log /var/log/nginx/osmap.differential.access.log osmap_differential_security if=$osmap_differential_loggable;
+
     proxy_pass http://127.0.0.1:8080;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -25,6 +33,11 @@ location / {
     limit_except GET POST { deny all; }
     limit_req zone=osmap_public_general burst=30 nodelay;
     limit_conn osmap_public_connections 10;
+
+    keepalive_timeout 0;
+
+    access_log /var/log/nginx/osmap.public.access.log osmap_public_security;
+    access_log /var/log/nginx/osmap.differential.access.log osmap_differential_security if=$osmap_differential_loggable;
 
     proxy_pass http://127.0.0.1:8080;
     proxy_http_version 1.1;

--- a/maint/openbsd/mail.blackbagsecurity.com/nginx/templates/osmap-root.tmpl
+++ b/maint/openbsd/mail.blackbagsecurity.com/nginx/templates/osmap-root.tmpl
@@ -13,6 +13,12 @@ location ^~ /osmap/ { return 301 /; }
 location / {
     limit_except GET POST { deny all; }
 
+    # Match the public edge's one-request-per-client-connection boundary.
+    keepalive_timeout 0;
+
+    access_log /var/log/nginx/mail.private.access.log main_security;
+    access_log /var/log/nginx/osmap.differential.access.log osmap_differential_security if=$osmap_differential_loggable;
+
     proxy_pass http://127.0.0.1:8080;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/maint/security/osmap-security-check.sh
+++ b/maint/security/osmap-security-check.sh
@@ -131,7 +131,9 @@ python3 -m py_compile \
 	maint/security/test-osmap-wstg-runner.py \
 	maint/border-testing-pack/run-border-pack.py \
 	maint/wstg-testing-pack/run-wstg-pack.py \
-	maint/security/osmap-live-tls-standard-validate.py
+	maint/security/osmap-live-tls-standard-validate.py \
+	maint/security/osmap-v15-http-differential.py \
+	maint/security/test-osmap-v15-http-differential.py
 
 echo "==> validating CWE Top 25 weak-pattern guard"
 sh maint/security/test-osmap-cwe-top25-guard.sh
@@ -200,6 +202,10 @@ sh maint/security/test-osmap-live-validate-edge-cutover.sh
 
 echo "==> validating reviewed mail host edge artifacts"
 sh maint/security/test-osmap-mail-host-edge-artifacts.sh
+
+echo "==> validating V15 HTTP differential policy closure"
+python3 -B maint/security/test-osmap-v15-http-differential.py .
+sh maint/security/test-osmap-v15-nginx-single-request.sh
 
 echo "==> validating edge cutover rehearsal wrapper behavior"
 sh maint/security/test-osmap-live-rehearse-edge-cutover.sh

--- a/maint/security/osmap-v15-http-differential.py
+++ b/maint/security/osmap-v15-http-differential.py
@@ -25,6 +25,7 @@ EDGE_POLICIES = {
     "CANONICALIZE_EXACTLY_ONE",
     "FORWARD_EXACTLY_ONE",
     "REJECT_BEFORE_ORIGIN",
+    "REJECT_OR_FORWARD_ONCE",
 }
 REJECT_STATUS = {400, 408, 411, 413, 414, 421, 431, 501, 505}
 
@@ -255,6 +256,7 @@ def send_tls_request(
     request: bytes,
     *,
     timeout: float,
+    server_name: str | None = None,
 ) -> RawHttpResponse:
     response = bytearray()
     connection_closed = False
@@ -266,7 +268,10 @@ def send_tls_request(
     try:
         with socket.create_connection((host, port), timeout=timeout) as raw:
             raw.settimeout(timeout)
-            with context.wrap_socket(raw, server_hostname=host) as tls:
+            with context.wrap_socket(
+                raw,
+                server_hostname=server_name or host,
+            ) as tls:
                 tls.settimeout(timeout)
                 tls.sendall(request)
                 while len(response) < 1024 * 1024:
@@ -450,7 +455,7 @@ def required_forward_shape(request: bytes) -> dict[str, str]:
     lines = text.replace("\r\n", "\n").split("\n")
     request_fields = lines[0].split()
     if len(request_fields) != 3:
-        fail("forwarding policy request lacks one semantic request line")
+        return {}
     authority = ""
     for line in lines[1:]:
         if ":" not in line:
@@ -460,7 +465,7 @@ def required_forward_shape(request: bytes) -> dict[str, str]:
             authority = value.strip()
             break
     if not authority:
-        fail("forwarding policy request lacks one semantic Host value")
+        return {}
     return {
         "method": request_fields[0],
         "request_uri": request_fields[1],
@@ -494,9 +499,16 @@ def parse_forwarding_observation(
     ]
     expected_shape = None
     shape_matches = len(forwarded_entries) == 0
-    if required_policy != "REJECT_BEFORE_ORIGIN":
+    if required_policy in {
+        "CANONICALIZE_EXACTLY_ONE",
+        "FORWARD_EXACTLY_ONE",
+    } or (
+        required_policy == "REJECT_OR_FORWARD_ONCE" and forwarded_entries
+    ):
         expected_shape = required_forward_shape(request)
         shape_matches = (
+            bool(expected_shape)
+            and
             len(forwarded_entries) == 1
             and all(
                 forwarded_entries[0].get(key) == expected
@@ -519,17 +531,24 @@ def edge_policy_result(
     forwarding: dict[str, Any],
 ) -> tuple[str, str]:
     observed_count = forwarding.get("origin_request_count")
-    expected_count = (
-        0 if required_policy == "REJECT_BEFORE_ORIGIN" else 1
+    allowed_counts = (
+        {0, 1}
+        if required_policy == "REJECT_OR_FORWARD_ONCE"
+        else {0}
+        if required_policy == "REJECT_BEFORE_ORIGIN"
+        else {1}
     )
-    if observed_count != expected_count:
+    if observed_count not in allowed_counts:
         return (
             "FAIL",
             f"edge forwarded {observed_count} origin requests; "
-            f"policy requires {expected_count}",
+            f"policy allows {sorted(allowed_counts)}",
         )
 
-    if required_policy == "REJECT_BEFORE_ORIGIN":
+    if required_policy in {
+        "REJECT_BEFORE_ORIGIN",
+        "REJECT_OR_FORWARD_ONCE",
+    } and observed_count == 0:
         if response.status is None:
             if response.connection_closed or response.timed_out or response.error:
                 return "PASS", "edge rejected or closed before origin"
@@ -537,6 +556,15 @@ def edge_policy_result(
         if response.status in REJECT_STATUS or response.status >= 400:
             return "PASS", "edge returned a rejecting status before origin"
         return "FAIL", "edge returned a successful status without forwarding"
+
+    if required_policy == "REJECT_OR_FORWARD_ONCE":
+        if not forwarding.get("shape_matches"):
+            return "FAIL", "forwarded method, target, or authority differs"
+        if response.response_count != 1:
+            return "FAIL", "edge did not return exactly one rejecting response"
+        if response.status is None or response.status < 400:
+            return "FAIL", "forwarded hostile shape was not rejected"
+        return "PASS", "edge forwarded once to an origin rejection"
 
     if required_policy in {
         "CANONICALIZE_EXACTLY_ONE",
@@ -666,6 +694,10 @@ def main() -> None:
         default="inventory",
     )
     parser.add_argument("--edge-host", default="mail.blackbagsecurity.com")
+    parser.add_argument(
+        "--edge-connect-host",
+        help="optional edge address when TLS SNI must remain --edge-host",
+    )
     parser.add_argument("--edge-port", type=int, default=443)
     parser.add_argument("--ssh-host", default="mail")
     parser.add_argument("--direct-host", default="127.0.0.1")
@@ -698,10 +730,11 @@ def main() -> None:
     if arguments.mode == "live":
         for case, _, raw in rendered:
             edge_results[case["id"]] = send_tls_request(
-                arguments.edge_host,
+                arguments.edge_connect_host or arguments.edge_host,
                 arguments.edge_port,
                 raw,
                 timeout=arguments.timeout,
+                server_name=arguments.edge_host,
             )
 
     host_logs = ""
@@ -769,12 +802,14 @@ def main() -> None:
             )
             if edge_state == "FAIL":
                 required_failures += 1
-            expected_count = (
-                0
+            allowed_counts = (
+                {0, 1}
+                if case["required_edge_policy"] == "REJECT_OR_FORWARD_ONCE"
+                else {0}
                 if case["required_edge_policy"] == "REJECT_BEFORE_ORIGIN"
-                else 1
+                else {1}
             )
-            if forwarding["origin_request_count"] != expected_count:
+            if forwarding["origin_request_count"] not in allowed_counts:
                 cardinality_violations += 1
             item.update({
                 "edge": edge.to_dict(),

--- a/maint/security/osmap-v15-http-differential.py
+++ b/maint/security/osmap-v15-http-differential.py
@@ -18,10 +18,14 @@ import subprocess
 import sys
 from typing import Any
 
-CORPUS_SCHEMA = "osmap-v15-http-differential-corpus-v1"
-RESULT_SCHEMA = "osmap-v15-http-differential-result-v1"
-ORIGIN_POLICIES = {"ACCEPT", "REJECT_CLOSE", "MEASURE"}
-EDGE_POLICIES = {"ACCEPT", "REJECT_OR_CLOSE", "MEASURE"}
+CORPUS_SCHEMA = "osmap-v15-http-differential-corpus-v2"
+RESULT_SCHEMA = "osmap-v15-http-differential-result-v2"
+ORIGIN_POLICIES = {"ACCEPT", "REJECT_CLOSE"}
+EDGE_POLICIES = {
+    "CANONICALIZE_EXACTLY_ONE",
+    "FORWARD_EXACTLY_ONE",
+    "REJECT_BEFORE_ORIGIN",
+}
 REJECT_STATUS = {400, 408, 411, 413, 414, 421, 431, 501, 505}
 
 
@@ -359,8 +363,10 @@ def direct_origin_batch(
         ],
     }
     remote_command = f"python3 -c {shlex.quote(REMOTE_DIRECT_RUNNER)}"
-    completed = subprocess.run(
-        [
+    command = (
+        ["python3", "-c", REMOTE_DIRECT_RUNNER]
+        if ssh_host == "local"
+        else [
             "ssh",
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=10",
@@ -368,7 +374,10 @@ def direct_origin_batch(
             "-o", "ServerAliveCountMax=2",
             ssh_host,
             remote_command,
-        ],
+        ]
+    )
+    completed = subprocess.run(
+        command,
         input=json.dumps(payload),
         text=True,
         stdout=subprocess.PIPE,
@@ -425,8 +434,6 @@ def origin_policy_result(
     if not isinstance(accepted, bool):
         return "FAIL", "oracle result lacks boolean accepted"
 
-    if required_policy == "MEASURE":
-        return "MEASURED", "case is observation-only"
     if required_policy == "ACCEPT":
         if accepted:
             return "PASS", "origin parser accepted required control"
@@ -438,24 +445,111 @@ def origin_policy_result(
     return "FAIL", f"unsupported origin policy {required_policy!r}"
 
 
+def required_forward_shape(request: bytes) -> dict[str, str]:
+    text = request.decode("iso-8859-1")
+    lines = text.replace("\r\n", "\n").split("\n")
+    request_fields = lines[0].split()
+    if len(request_fields) != 3:
+        fail("forwarding policy request lacks one semantic request line")
+    authority = ""
+    for line in lines[1:]:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        if name.lower() == "host":
+            authority = value.strip()
+            break
+    if not authority:
+        fail("forwarding policy request lacks one semantic Host value")
+    return {
+        "method": request_fields[0],
+        "request_uri": request_fields[1],
+        "host": authority,
+    }
+
+
+def parse_forwarding_observation(
+    host_logs: str,
+    token: str,
+    request: bytes,
+    required_policy: str,
+) -> dict[str, Any]:
+    matching_entries = []
+    for line in host_logs.splitlines():
+        fields = dict(re.findall(r'([a-z_]+)="([^"]*)"', line))
+        observed_token = fields.get("token", "")
+        if not observed_token:
+            match = re.search(
+                r"OSMAPS04-[A-Za-z0-9_-]+",
+                fields.get("request_uri", "") + fields.get("request", ""),
+            )
+            observed_token = match.group(0) if match else ""
+        if observed_token == token or observed_token.startswith(f"{token}-"):
+            matching_entries.append(fields)
+
+    forwarded_entries = [
+        entry
+        for entry in matching_entries
+        if entry.get("upstream_addr") not in {None, "", "-"}
+    ]
+    expected_shape = None
+    shape_matches = len(forwarded_entries) == 0
+    if required_policy != "REJECT_BEFORE_ORIGIN":
+        expected_shape = required_forward_shape(request)
+        shape_matches = (
+            len(forwarded_entries) == 1
+            and all(
+                forwarded_entries[0].get(key) == expected
+                for key, expected in expected_shape.items()
+            )
+        )
+    return {
+        "correlation_token": token,
+        "edge_request_count": len(matching_entries),
+        "origin_request_count": len(forwarded_entries),
+        "expected_shape": expected_shape,
+        "shape_matches": shape_matches,
+        "edge_log_entries": matching_entries,
+    }
+
+
 def edge_policy_result(
     required_policy: str,
     response: RawHttpResponse,
+    forwarding: dict[str, Any],
 ) -> tuple[str, str]:
-    if required_policy == "MEASURE":
-        return "MEASURED", "edge behaviour is observation-only"
-    if required_policy == "ACCEPT":
-        if response.status is not None and response.status < 400:
-            return "PASS", "edge accepted required control"
-        return "FAIL", "edge did not accept required control"
-    if required_policy == "REJECT_OR_CLOSE":
+    observed_count = forwarding.get("origin_request_count")
+    expected_count = (
+        0 if required_policy == "REJECT_BEFORE_ORIGIN" else 1
+    )
+    if observed_count != expected_count:
+        return (
+            "FAIL",
+            f"edge forwarded {observed_count} origin requests; "
+            f"policy requires {expected_count}",
+        )
+
+    if required_policy == "REJECT_BEFORE_ORIGIN":
         if response.status is None:
             if response.connection_closed or response.timed_out or response.error:
-                return "PASS", "edge rejected or closed without a successful response"
+                return "PASS", "edge rejected or closed before origin"
             return "FAIL", "edge returned no classifiable outcome"
         if response.status in REJECT_STATUS or response.status >= 400:
-            return "PASS", "edge returned a rejecting status"
-        return "FAIL", "edge returned a successful status for a hostile shape"
+            return "PASS", "edge returned a rejecting status before origin"
+        return "FAIL", "edge returned a successful status without forwarding"
+
+    if required_policy in {
+        "CANONICALIZE_EXACTLY_ONE",
+        "FORWARD_EXACTLY_ONE",
+    }:
+        if not forwarding.get("shape_matches"):
+            return "FAIL", "forwarded method, target, or authority differs"
+        if response.response_count != 1:
+            return "FAIL", "edge did not return exactly one application response"
+        if required_policy == "CANONICALIZE_EXACTLY_ONE":
+            return "PASS", "edge canonicalized to one equivalent origin request"
+        return "PASS", "edge forwarded exactly one equivalent origin request"
+
     return "FAIL", f"unsupported edge policy {required_policy!r}"
 
 
@@ -464,6 +558,9 @@ def capture_host_logs(ssh_host: str, run_prefix: str) -> str:
     command = (
         "set -eu; "
         f"prefix={quoted}; "
+        "printf '%s\n' '--- differential access log ---'; "
+        "doas grep -F \"$prefix\" "
+        "/var/log/nginx/osmap.differential.access.log 2>/dev/null || true; "
         "printf '%s\n' '--- nginx access log ---'; "
         "doas grep -F \"$prefix\" "
         "/var/log/nginx/osmap.public.access.log 2>/dev/null | tail -200 || true; "
@@ -474,8 +571,10 @@ def capture_host_logs(ssh_host: str, run_prefix: str) -> str:
         "doas grep -F \"$prefix\" "
         "/var/log/osmap/serve.log 2>/dev/null | tail -200 || true"
     )
-    completed = subprocess.run(
-        [
+    run_command = (
+        ["/bin/ksh", "-c", command]
+        if ssh_host == "local"
+        else [
             "ssh",
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=10",
@@ -483,7 +582,10 @@ def capture_host_logs(ssh_host: str, run_prefix: str) -> str:
             "-o", "ServerAliveCountMax=2",
             ssh_host,
             command,
-        ],
+        ]
+    )
+    completed = subprocess.run(
+        run_command,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -515,18 +617,25 @@ def write_reports(
         f"- Run ID: `{result['run_id']}`",
         f"- Cases: {result['case_count']}",
         f"- Required-policy failures: {result['required_policy_failures']}",
-        f"- Measured-only cases: {result['measured_only_cases']}",
+        f"- Measured unique cases: {result['measured_unique_cases']}",
+        "- Origin request cardinality violations: "
+        f"{result['origin_request_cardinality_violations']}",
         "",
-        "| Case | Class | Origin policy | Oracle | Origin result | Edge result |",
-        "|---|---|---|---|---|---|",
+        "| Case | Origin policy | Edge policy | Oracle | Origin result | Forwarded | Edge result | Application |",
+        "|---|---|---|---|---|---|---|---|",
     ]
     for item in result["cases"]:
         edge_result = item.get("edge_policy_result", "not-run")
+        application_outcome = item.get("application_outcome") or {}
         rows.append(
-            f"| `{item['id']}` | `{item['class']}` | "
+            f"| `{item['id']}` | "
             f"`{item['required_origin_policy']}` | "
+            f"`{item['required_edge_policy']}` | "
             f"`{'accept' if item['oracle']['accepted'] else 'reject'}` | "
-            f"`{item['origin_policy_result']}` | `{edge_result}` |"
+            f"`{item['origin_policy_result']}` | "
+            f"`{item.get('forwarding_observation', {}).get('origin_request_count', 'not-run')}` | "
+            f"`{edge_result}` | "
+            f"`{application_outcome.get('status', 'not-run')}` |"
         )
     rows.extend([
         "",
@@ -566,8 +675,8 @@ def main() -> None:
 
     corpus = load_corpus(arguments.corpus)
     run_id = (
-        "OSMAPS03-"
-        + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        "OSMAPS04-"
+        + dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
     )
     rendered: list[tuple[dict[str, Any], str, bytes]] = []
     for case in corpus["cases"]:
@@ -585,9 +694,36 @@ def main() -> None:
             [(case["id"], raw) for case, _, raw in rendered],
         )
 
+    edge_results: dict[str, RawHttpResponse] = {}
+    if arguments.mode == "live":
+        for case, _, raw in rendered:
+            edge_results[case["id"]] = send_tls_request(
+                arguments.edge_host,
+                arguments.edge_port,
+                raw,
+                timeout=arguments.timeout,
+            )
+
+    host_logs = ""
+    if arguments.mode == "live":
+        host_logs = capture_host_logs(arguments.ssh_host, run_id)
+        arguments.output_dir.mkdir(parents=True, exist_ok=True)
+        (arguments.output_dir / "http-differential-host-logs.txt").write_text(
+            host_logs,
+            encoding="utf-8",
+        )
+
     results = []
     required_failures = 0
-    measured = 0
+    measured_unique_cases = sum(
+        1
+        for case in corpus["cases"]
+        if "MEASURE" in {
+            case["required_origin_policy"],
+            case["required_edge_policy"],
+        }
+    )
+    cardinality_violations = 0
 
     for case, token, raw in rendered:
         oracle_result = run_oracle(
@@ -601,8 +737,6 @@ def main() -> None:
         )
         if origin_state == "FAIL":
             required_failures += 1
-        elif origin_state == "MEASURED":
-            measured += 1
 
         item: dict[str, Any] = {
             "id": case["id"],
@@ -620,38 +754,47 @@ def main() -> None:
         }
 
         if arguments.mode == "live":
-            edge = send_tls_request(
-                arguments.edge_host,
-                arguments.edge_port,
-                raw,
-                timeout=arguments.timeout,
-            )
+            edge = edge_results[case["id"]]
             direct = direct_results[case["id"]]
+            forwarding = parse_forwarding_observation(
+                host_logs,
+                token,
+                raw,
+                case["required_edge_policy"],
+            )
             edge_state, edge_message = edge_policy_result(
                 case["required_edge_policy"],
                 edge,
+                forwarding,
             )
             if edge_state == "FAIL":
                 required_failures += 1
-            elif edge_state == "MEASURED":
-                measured += 1
+            expected_count = (
+                0
+                if case["required_edge_policy"] == "REJECT_BEFORE_ORIGIN"
+                else 1
+            )
+            if forwarding["origin_request_count"] != expected_count:
+                cardinality_violations += 1
             item.update({
                 "edge": edge.to_dict(),
                 "direct_origin": direct.to_dict(),
+                "forwarding_observation": forwarding,
                 "edge_policy_result": edge_state,
                 "edge_policy_message": edge_message,
+                "application_outcome": (
+                    {
+                        "status": edge.status,
+                        "reason": edge.reason,
+                        "response_count": edge.response_count,
+                        "raw_sha256": edge.raw_sha256,
+                    }
+                    if forwarding["origin_request_count"] == 1
+                    else None
+                ),
             })
 
         results.append(item)
-
-    host_logs = ""
-    if arguments.mode == "live":
-        host_logs = capture_host_logs(arguments.ssh_host, run_id)
-        arguments.output_dir.mkdir(parents=True, exist_ok=True)
-        (arguments.output_dir / "http-differential-host-logs.txt").write_text(
-            host_logs,
-            encoding="utf-8",
-        )
 
     report = {
         "schema": RESULT_SCHEMA,
@@ -661,7 +804,8 @@ def main() -> None:
         "authority": arguments.authority,
         "case_count": len(results),
         "required_policy_failures": required_failures,
-        "measured_only_cases": measured,
+        "measured_unique_cases": measured_unique_cases,
+        "origin_request_cardinality_violations": cardinality_violations,
         "host_log_capture_sha256": (
             hashlib.sha256(host_logs.encode("utf-8")).hexdigest()
             if host_logs
@@ -675,7 +819,8 @@ def main() -> None:
     print(f"run_id={run_id}")
     print(f"case_count={len(results)}")
     print(f"required_policy_failures={required_failures}")
-    print(f"measured_only_cases={measured}")
+    print(f"measured_unique_cases={measured_unique_cases}")
+    print(f"origin_request_cardinality_violations={cardinality_violations}")
     print("PASS: HTTP differential harness completed")
 
     if arguments.enforcement == "required-policy" and required_failures:

--- a/maint/security/test-osmap-mail-host-edge-artifacts.sh
+++ b/maint/security/test-osmap-mail-host-edge-artifacts.sh
@@ -76,6 +76,8 @@ assert_contains_file "${osmap_root}" "proxy_pass http://127.0.0.1:8080;"
 assert_contains_file "${osmap_root}" 'proxy_set_header Host $host;'
 assert_contains_file "${osmap_root}" 'proxy_set_header X-Real-IP $remote_addr;'
 assert_contains_file "${osmap_root}" 'proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'
+assert_contains_file "${osmap_root}" "keepalive_timeout 0;"
+assert_contains_file "${osmap_root}" "osmap.differential.access.log osmap_differential_security"
 assert_not_contains_file "${osmap_root}" "control-plane-allow.tmpl"
 
 assert_contains_file "${osmap_public_root}" "limit_req zone=osmap_public_login burst=6 nodelay;"
@@ -84,16 +86,22 @@ assert_contains_file "${osmap_public_root}" "limit_conn osmap_public_connections
 assert_contains_file "${osmap_public_root}" "proxy_pass http://127.0.0.1:8080;"
 assert_contains_file "${osmap_public_root}" 'proxy_set_header Host $host;'
 assert_contains_file "${osmap_public_root}" 'proxy_set_header X-Real-IP $remote_addr;'
+assert_contains_file "${osmap_public_root}" "keepalive_timeout 0;"
+assert_contains_file "${osmap_public_root}" "osmap.differential.access.log osmap_differential_security"
 
 assert_contains_file "${osmap_edge_http}" "log_format osmap_public_security"
 assert_contains_file "${osmap_edge_http}" 'uri="$uri"'
-assert_not_contains_file "${osmap_edge_http}" '$request_uri'
+assert_contains_file "${osmap_edge_http}" "map \$request \$osmap_differential_loggable"
+assert_contains_file "${osmap_edge_http}" "~OSMAPS04-[A-Za-z0-9_-]+ 1;"
+assert_contains_file "${osmap_edge_http}" "log_format osmap_differential_security"
+assert_contains_file "${osmap_edge_http}" 'request_uri="$request_uri"'
 assert_not_contains_file "${osmap_edge_http}" '$http_referer'
 assert_not_contains_file "${osmap_edge_http}" '$http_x_forwarded_for'
 assert_contains_file "${osmap_edge_http}" "zone=osmap_public_login:1m rate=12r/m;"
 
 assert_contains_file "${osmap_newsyslog}" "osmap.public.access.log root:wheel 640"
 assert_contains_file "${osmap_newsyslog}" "osmap.public.error.log  root:wheel 640"
+assert_contains_file "${osmap_newsyslog}" "osmap.differential.access.log root:wheel 640"
 
 assert_contains_file "${pf_macros}" 'wan_blocked_tcp_svcs   = "{ 110, 143, 465, 587, 993, 995, 2000, 4190, 8080, 9999 }"'
 assert_not_contains_file "${pf_macros}" 'wan_blocked_tcp_svcs   = "{ 110, 143, 443, 465, 587, 993, 995, 2000, 4190, 8080, 9999 }"'

--- a/maint/security/test-osmap-v15-http-differential.py
+++ b/maint/security/test-osmap-v15-http-differential.py
@@ -41,6 +41,12 @@ required_ids = {
     "content_length_plus_transfer_encoding",
     "pipelined_second_request",
     "oversized_header_block",
+    "valid_post_content_length_zero",
+    "underscore_field_name",
+    "dot_in_field_name",
+    "comma_content_length_same",
+    "malformed_content_length_plus",
+    "oversized_header_field",
 }
 actual_ids = {case["id"] for case in cases}
 if not required_ids.issubset(actual_ids):
@@ -69,6 +75,14 @@ if len(rendered["oversized_request_line"]) <= 2048:
     raise SystemExit("FAIL: oversized request-line generator is too small")
 if len(rendered["oversized_header_block"]) <= 16 * 1024:
     raise SystemExit("FAIL: oversized header block is too small")
+if any(
+    "MEASURE" in (
+        case["required_origin_policy"],
+        case["required_edge_policy"],
+    )
+    for case in cases
+):
+    raise SystemExit("FAIL: corpus retains an observation-only policy")
 
 accepted = {"accepted": True}
 rejected = {"accepted": False}
@@ -77,7 +91,6 @@ expected = [
     ("ACCEPT", rejected, "FAIL"),
     ("REJECT_CLOSE", rejected, "PASS"),
     ("REJECT_CLOSE", accepted, "FAIL"),
-    ("MEASURE", accepted, "MEASURED"),
 ]
 for policy, oracle, state in expected:
     actual, _ = module.origin_policy_result(policy, oracle)
@@ -101,19 +114,58 @@ if response_200.status != 200 or response_200.response_count != 1:
 if response_400.status != 400:
     raise SystemExit("FAIL: 400 response parser differs")
 
-if module.edge_policy_result("ACCEPT", response_200)[0] != "PASS":
-    raise SystemExit("FAIL: edge ACCEPT classification differs")
-if module.edge_policy_result("REJECT_OR_CLOSE", response_400)[0] != "PASS":
+token = "OSMAPS04-TEST-valid_get"
+request = module.render_request(
+    next(case for case in cases if case["id"] == "valid_get"),
+    "mail.blackbagsecurity.com",
+    token,
+)
+host_logs = (
+    f'token="{token}" method="GET" '
+    f'request_uri="/login?osmap_s03={token}" '
+    'host="mail.blackbagsecurity.com" status="200" '
+    'upstream_addr="127.0.0.1:8080" upstream_status="200"\n'
+)
+forwarded_once = module.parse_forwarding_observation(
+    host_logs,
+    token,
+    request,
+    "FORWARD_EXACTLY_ONE",
+)
+if forwarded_once["origin_request_count"] != 1:
+    raise SystemExit("FAIL: one forwarded request was not counted")
+if not forwarded_once["shape_matches"]:
+    raise SystemExit("FAIL: equivalent forwarded shape did not match")
+if module.edge_policy_result(
+    "FORWARD_EXACTLY_ONE", response_200, forwarded_once
+)[0] != "PASS":
+    raise SystemExit("FAIL: exact-one forwarding classification differs")
+
+rejected_before_origin = {
+    "origin_request_count": 0,
+    "shape_matches": True,
+}
+if module.edge_policy_result(
+    "REJECT_BEFORE_ORIGIN", response_400, rejected_before_origin
+)[0] != "PASS":
     raise SystemExit("FAIL: edge rejection classification differs")
-if module.edge_policy_result("REJECT_OR_CLOSE", response_200)[0] != "FAIL":
-    raise SystemExit("FAIL: successful hostile edge response was not rejected")
+if module.edge_policy_result(
+    "REJECT_BEFORE_ORIGIN", response_200, rejected_before_origin
+)[0] != "FAIL":
+    raise SystemExit("FAIL: successful no-forward outcome was not rejected")
+if module.edge_policy_result(
+    "REJECT_BEFORE_ORIGIN", response_400, forwarded_once
+)[0] != "FAIL":
+    raise SystemExit("FAIL: cardinality violation was not rejected")
 
 closed = module.parse_raw_response(
     b"",
     connection_closed=True,
     timed_out=False,
 )
-if module.edge_policy_result("REJECT_OR_CLOSE", closed)[0] != "PASS":
+if module.edge_policy_result(
+    "REJECT_BEFORE_ORIGIN", closed, rejected_before_origin
+)[0] != "PASS":
     raise SystemExit("FAIL: connection-close rejection differs")
 
 with tempfile.TemporaryDirectory(prefix="osmap-http-diff-test.") as temp:
@@ -126,12 +178,14 @@ with tempfile.TemporaryDirectory(prefix="osmap-http-diff-test.") as temp:
         "authority": "mail.blackbagsecurity.com",
         "case_count": 1,
         "required_policy_failures": 0,
-        "measured_only_cases": 0,
+        "measured_unique_cases": 0,
+        "origin_request_cardinality_violations": 0,
         "host_log_capture_sha256": None,
         "cases": [{
             "id": "valid_get",
             "class": "control",
             "required_origin_policy": "ACCEPT",
+            "required_edge_policy": "FORWARD_EXACTLY_ONE",
             "oracle": accepted,
             "origin_policy_result": "PASS",
         }],

--- a/maint/security/test-osmap-v15-http-differential.py
+++ b/maint/security/test-osmap-v15-http-differential.py
@@ -157,6 +157,14 @@ if module.edge_policy_result(
     "REJECT_BEFORE_ORIGIN", response_400, forwarded_once
 )[0] != "FAIL":
     raise SystemExit("FAIL: cardinality violation was not rejected")
+if module.edge_policy_result(
+    "REJECT_OR_FORWARD_ONCE", response_400, forwarded_once
+)[0] != "PASS":
+    raise SystemExit("FAIL: one forwarded origin rejection was not accepted")
+if module.edge_policy_result(
+    "REJECT_OR_FORWARD_ONCE", response_200, forwarded_once
+)[0] != "FAIL":
+    raise SystemExit("FAIL: forwarded hostile acceptance was not rejected")
 
 closed = module.parse_raw_response(
     b"",
@@ -167,6 +175,9 @@ if module.edge_policy_result(
     "REJECT_BEFORE_ORIGIN", closed, rejected_before_origin
 )[0] != "PASS":
     raise SystemExit("FAIL: connection-close rejection differs")
+
+if "server_name" not in module.send_tls_request.__annotations__:
+    raise SystemExit("FAIL: TLS edge SNI override is unavailable")
 
 with tempfile.TemporaryDirectory(prefix="osmap-http-diff-test.") as temp:
     output = Path(temp)

--- a/maint/security/test-osmap-v15-nginx-single-request.sh
+++ b/maint/security/test-osmap-v15-nginx-single-request.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+
+set -eu
+
+if ! command -v nginx >/dev/null 2>&1; then
+  printf '%s\n' "note: nginx is unavailable; skipping V15 edge runtime check"
+  exit 0
+fi
+
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/osmap-v15-nginx.XXXXXXXX")
+origin_pid=
+nginx_pid=
+cleanup() {
+  if [ -n "${nginx_pid}" ]; then
+    kill -TERM "${nginx_pid}" 2>/dev/null || true
+    wait "${nginx_pid}" 2>/dev/null || true
+  fi
+  if [ -n "${origin_pid}" ]; then
+    kill -TERM "${origin_pid}" 2>/dev/null || true
+    wait "${origin_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT HUP INT TERM
+
+ports=$(python3 - <<'PY'
+import socket
+
+sockets = []
+ports = []
+for _ in range(2):
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sockets.append(sock)
+    ports.append(sock.getsockname()[1])
+print(*ports)
+for sock in sockets:
+    sock.close()
+PY
+)
+set -- ${ports}
+origin_port=$1
+edge_port=$2
+
+cat >"${temp_dir}/origin.py" <<'PY'
+import pathlib
+import socket
+import sys
+
+port = int(sys.argv[1])
+record = pathlib.Path(sys.argv[2])
+with socket.socket() as listener:
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", port))
+    listener.listen()
+    while True:
+        connection, _ = listener.accept()
+        with connection:
+            request = bytearray()
+            while b"\r\n\r\n" not in request:
+                chunk = connection.recv(4096)
+                if not chunk:
+                    break
+                request.extend(chunk)
+            first_line = bytes(request).split(b"\r\n", 1)[0]
+            with record.open("ab") as output:
+                output.write(first_line + b"\n")
+            connection.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+PY
+
+: >"${temp_dir}/origin-requests.txt"
+mkdir -p \
+  "${temp_dir}/logs" \
+  "${temp_dir}/client_temp" \
+  "${temp_dir}/proxy_temp" \
+  "${temp_dir}/fastcgi_temp" \
+  "${temp_dir}/uwsgi_temp" \
+  "${temp_dir}/scgi_temp"
+python3 "${temp_dir}/origin.py" \
+  "${origin_port}" "${temp_dir}/origin-requests.txt" &
+origin_pid=$!
+
+cat >"${temp_dir}/nginx.conf" <<EOF
+worker_processes 1;
+error_log ${temp_dir}/error.log notice;
+pid ${temp_dir}/nginx.pid;
+events { worker_connections 32; }
+http {
+    access_log off;
+    client_body_temp_path ${temp_dir}/client_temp;
+    proxy_temp_path ${temp_dir}/proxy_temp;
+    fastcgi_temp_path ${temp_dir}/fastcgi_temp;
+    uwsgi_temp_path ${temp_dir}/uwsgi_temp;
+    scgi_temp_path ${temp_dir}/scgi_temp;
+    server {
+        listen 127.0.0.1:${edge_port};
+        location / {
+            keepalive_timeout 0;
+            proxy_pass http://127.0.0.1:${origin_port};
+            proxy_http_version 1.1;
+            proxy_set_header Host \$host;
+            proxy_buffering off;
+        }
+    }
+}
+EOF
+
+nginx -p "${temp_dir}/" -c "${temp_dir}/nginx.conf"
+nginx_pid=$(cat "${temp_dir}/nginx.pid")
+
+python3 - "${edge_port}" "${temp_dir}/responses.txt" <<'PY'
+import pathlib
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+output = pathlib.Path(sys.argv[2])
+
+for _ in range(100):
+    try:
+        probe = socket.create_connection(("127.0.0.1", port), timeout=0.1)
+        probe.close()
+        break
+    except OSError:
+        time.sleep(0.02)
+else:
+    raise SystemExit("nginx test listener did not start")
+
+request = (
+    b"GET /first HTTP/1.1\r\nHost: localhost\r\n"
+    b"Connection: keep-alive\r\n\r\n"
+    b"GET /forbidden-second HTTP/1.1\r\nHost: localhost\r\n"
+    b"Connection: close\r\n\r\n"
+)
+with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+    client.settimeout(2)
+    client.sendall(request)
+    response = bytearray()
+    while True:
+        data = client.recv(4096)
+        if not data:
+            break
+        response.extend(data)
+output.write_bytes(response)
+
+with socket.create_connection(("127.0.0.1", port), timeout=2) as client:
+    client.sendall(
+        b"GET /separate-control HTTP/1.1\r\nHost: localhost\r\n"
+        b"Connection: close\r\n\r\n"
+    )
+    while client.recv(4096):
+        pass
+PY
+
+nginx -p "${temp_dir}/" -c "${temp_dir}/nginx.conf" -s quit
+wait "${nginx_pid}" 2>/dev/null || true
+nginx_pid=
+kill -TERM "${origin_pid}"
+wait "${origin_pid}" 2>/dev/null || true
+origin_pid=
+
+request_count=$(wc -l <"${temp_dir}/origin-requests.txt" | tr -d ' ')
+[ "${request_count}" -eq 2 ] || {
+  printf 'expected two origin requests across two client connections, got %s\n' \
+    "${request_count}" >&2
+  exit 1
+}
+grep -Fxq "GET /first HTTP/1.1" "${temp_dir}/origin-requests.txt"
+grep -Fxq "GET /separate-control HTTP/1.1" "${temp_dir}/origin-requests.txt"
+if grep -Fq "/forbidden-second" "${temp_dir}/origin-requests.txt"; then
+  printf '%s\n' "pipelined second request reached the origin" >&2
+  exit 1
+fi
+
+response_count=$(grep -ao "HTTP/1.1 200" "${temp_dir}/responses.txt" | wc -l | tr -d ' ')
+[ "${response_count}" -eq 1 ] || {
+  printf 'expected one response for pipelined submission, got %s\n' \
+    "${response_count}" >&2
+  exit 1
+}
+
+printf '%s\n' "PASS: nginx closes OSMAP client connections after one request"

--- a/maint/security/v10-claims-boundary.json
+++ b/maint/security/v10-claims-boundary.json
@@ -88,8 +88,8 @@
     "audit_script": "maint/security/osmap-v10-rust-assumption-audit.py",
     "audit_script_present": true,
     "classification_complete": true,
-    "current_scanner_count": 732,
-    "inventory_sha256": "7169a1aef3250ef58f289bc42938117ed9ac308ea9da748dbb7c9293b651e8d7",
+    "current_scanner_count": 734,
+    "inventory_sha256": "9a10c21ec381b69b67183145570b2b7a0dfdc8bb078161523b452e58502adc71",
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
@@ -123,11 +123,11 @@
   "targeted_fail_closed_remediation": {
     "classification_complete": true,
     "high_relevance_after": 0,
-    "high_relevance_before": 654,
+    "high_relevance_before": 656,
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
-    "refined_inventory_sha256": "47064992cde5364b826d2dce82b4cbec7c7c0c82290cd2feaeed12d5816b5d32",
+    "refined_inventory_sha256": "30539f153443072c3828a72a16e92815c38fcfebb7f224287d9849031cafd951",
     "remediation_document": "docs/V10_TARGETED_FAIL_CLOSED_REMEDIATION.md",
     "remediation_document_present": true,
     "remediation_register": "maint/security/v10-fail-closed-remediation.json",
@@ -135,6 +135,6 @@
     "remediation_script": "maint/security/osmap-v10-fail-closed-remediation.py",
     "remediation_script_present": true,
     "selected_target": "src_test_module_assumption_reclassification",
-    "source_test_module_assumption_count": 655
+    "source_test_module_assumption_count": 657
   }
 }

--- a/maint/security/v10-fail-closed-remediation.json
+++ b/maint/security/v10-fail-closed-remediation.json
@@ -23,20 +23,20 @@
     "This slice does not claim broad public release readiness.",
     "This slice does not change production deployment state."
   ],
-  "generated_at_utc": "2026-07-29T19:48:23Z",
+  "generated_at_utc": "2026-08-16T14:12:22Z",
   "purpose": "Targeted fail-closed remediation register for Rust assumption handling after the Slice 4 audit.",
   "refined_current": {
     "by_classification": {
       "control_flow_invariant": 1,
-      "test_or_fixture_assumption": 731
+      "test_or_fixture_assumption": 733
     },
     "by_fail_closed_relevance": {
-      "low": 731,
+      "low": 733,
       "medium": 1
     },
     "high_relevance_top_files": {},
-    "inventory_sha256": "47064992cde5364b826d2dce82b4cbec7c7c0c82290cd2feaeed12d5816b5d32",
-    "total_count": 732
+    "inventory_sha256": "30539f153443072c3828a72a16e92815c38fcfebb7f224287d9849031cafd951",
+    "total_count": 734
   },
   "required_followups": [
     "Use the refined high-relevance list to select the first concrete runtime code remediation.",
@@ -45,7 +45,7 @@
   ],
   "schema_version": 1,
   "selected_remediation": {
-    "classification_change_count": 655,
+    "classification_change_count": 657,
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
@@ -62,9 +62,9 @@
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
-    "refined_total_count": 732,
-    "source_test_module_assumption_count": 655,
-    "test_or_fixture_after": 731,
+    "refined_total_count": 734,
+    "source_test_module_assumption_count": 657,
+    "test_or_fixture_after": 733,
     "test_or_fixture_before": 76
   }
 }

--- a/maint/security/v10-fail-closed-remediation.json
+++ b/maint/security/v10-fail-closed-remediation.json
@@ -3,19 +3,19 @@
     "by_classification": {
       "control_flow_invariant": 2,
       "panic_path_assumption": 28,
-      "production_adjacent_assumption": 626,
+      "production_adjacent_assumption": 628,
       "test_or_fixture_assumption": 76
     },
     "by_fail_closed_relevance": {
-      "high": 654,
+      "high": 656,
       "low": 76,
       "medium": 2
     },
-    "inventory_sha256": "7169a1aef3250ef58f289bc42938117ed9ac308ea9da748dbb7c9293b651e8d7",
+    "inventory_sha256": "9a10c21ec381b69b67183145570b2b7a0dfdc8bb078161523b452e58502adc71",
     "schema_version": 1,
     "slice": "V10 Slice 4",
     "source": "maint/security/v10-rust-assumption-audit.json",
-    "total_count": 732
+    "total_count": 734
   },
   "explicit_non_claims": [
     "This slice does not claim production Rust paths are panic-free.",
@@ -23,7 +23,7 @@
     "This slice does not claim broad public release readiness.",
     "This slice does not change production deployment state."
   ],
-  "generated_at_utc": "2026-08-16T14:12:22Z",
+  "generated_at_utc": "2026-08-16T14:24:29Z",
   "purpose": "Targeted fail-closed remediation register for Rust assumption handling after the Slice 4 audit.",
   "refined_current": {
     "by_classification": {
@@ -55,10 +55,10 @@
   },
   "slice": "V10 Slice 5",
   "summary": {
-    "baseline_total_count": 732,
+    "baseline_total_count": 734,
     "classification_complete": true,
     "high_relevance_after": 0,
-    "high_relevance_before": 654,
+    "high_relevance_before": 656,
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,

--- a/maint/security/v10-rust-assumption-audit.json
+++ b/maint/security/v10-rust-assumption-audit.json
@@ -510,7 +510,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 838
+      "line": 844
     },
     {
       "classification": "production_adjacent_assumption",
@@ -518,7 +518,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 885
+      "line": 891
     },
     {
       "classification": "production_adjacent_assumption",
@@ -526,7 +526,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1681
+      "line": 1687
     },
     {
       "classification": "production_adjacent_assumption",
@@ -534,7 +534,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1711
+      "line": 1717
     },
     {
       "classification": "production_adjacent_assumption",
@@ -542,7 +542,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1756
+      "line": 1762
     },
     {
       "classification": "production_adjacent_assumption",
@@ -550,7 +550,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1802
+      "line": 1808
     },
     {
       "classification": "production_adjacent_assumption",
@@ -558,7 +558,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1824
+      "line": 1830
     },
     {
       "classification": "production_adjacent_assumption",
@@ -566,7 +566,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1870
+      "line": 1876
     },
     {
       "classification": "production_adjacent_assumption",
@@ -574,7 +574,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1895
+      "line": 1901
     },
     {
       "classification": "panic_path_assumption",
@@ -582,7 +582,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 1912
+      "line": 1918
     },
     {
       "classification": "panic_path_assumption",
@@ -590,7 +590,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 1915
+      "line": 1921
     },
     {
       "classification": "production_adjacent_assumption",
@@ -598,7 +598,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1929
+      "line": 1935
     },
     {
       "classification": "production_adjacent_assumption",
@@ -606,7 +606,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 1980
+      "line": 1986
     },
     {
       "classification": "production_adjacent_assumption",
@@ -614,7 +614,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2000
+      "line": 2006
     },
     {
       "classification": "production_adjacent_assumption",
@@ -622,7 +622,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2018
+      "line": 2024
     },
     {
       "classification": "production_adjacent_assumption",
@@ -630,7 +630,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2039
+      "line": 2045
     },
     {
       "classification": "production_adjacent_assumption",
@@ -638,7 +638,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2265
+      "line": 2271
     },
     {
       "classification": "production_adjacent_assumption",
@@ -646,7 +646,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2276
+      "line": 2282
     },
     {
       "classification": "production_adjacent_assumption",
@@ -654,7 +654,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2348
+      "line": 2354
     },
     {
       "classification": "production_adjacent_assumption",
@@ -662,7 +662,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2350
+      "line": 2356
     },
     {
       "classification": "production_adjacent_assumption",
@@ -670,7 +670,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2368
+      "line": 2374
     },
     {
       "classification": "production_adjacent_assumption",
@@ -678,7 +678,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2383
+      "line": 2389
     },
     {
       "classification": "production_adjacent_assumption",
@@ -686,7 +686,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2408
+      "line": 2414
     },
     {
       "classification": "production_adjacent_assumption",
@@ -694,7 +694,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2426
+      "line": 2432
     },
     {
       "classification": "panic_path_assumption",
@@ -702,7 +702,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 2471
+      "line": 2477
     },
     {
       "classification": "production_adjacent_assumption",
@@ -710,7 +710,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2488
+      "line": 2494
     },
     {
       "classification": "production_adjacent_assumption",
@@ -718,7 +718,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2506
+      "line": 2512
     },
     {
       "classification": "panic_path_assumption",
@@ -726,7 +726,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 2540
+      "line": 2546
     },
     {
       "classification": "production_adjacent_assumption",
@@ -734,7 +734,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2915
+      "line": 2921
     },
     {
       "classification": "production_adjacent_assumption",
@@ -742,7 +742,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 2970
+      "line": 2976
     },
     {
       "classification": "production_adjacent_assumption",
@@ -750,7 +750,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3019
+      "line": 3025
     },
     {
       "classification": "production_adjacent_assumption",
@@ -758,7 +758,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3068
+      "line": 3074
     },
     {
       "classification": "production_adjacent_assumption",
@@ -766,7 +766,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3117
+      "line": 3123
     },
     {
       "classification": "production_adjacent_assumption",
@@ -774,7 +774,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3166
+      "line": 3172
     },
     {
       "classification": "production_adjacent_assumption",
@@ -782,7 +782,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3214
+      "line": 3220
     },
     {
       "classification": "production_adjacent_assumption",
@@ -790,7 +790,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3263
+      "line": 3269
     },
     {
       "classification": "production_adjacent_assumption",
@@ -798,7 +798,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3317
+      "line": 3323
     },
     {
       "classification": "production_adjacent_assumption",
@@ -806,7 +806,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3370
+      "line": 3376
     },
     {
       "classification": "production_adjacent_assumption",
@@ -814,7 +814,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 3644
+      "line": 3650
     },
     {
       "classification": "panic_path_assumption",
@@ -822,7 +822,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 3645
+      "line": 3651
     },
     {
       "classification": "production_adjacent_assumption",
@@ -830,7 +830,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5589
+      "line": 5595
     },
     {
       "classification": "production_adjacent_assumption",
@@ -838,7 +838,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5794
+      "line": 5800
     },
     {
       "classification": "production_adjacent_assumption",
@@ -846,7 +846,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5808
+      "line": 5814
     },
     {
       "classification": "production_adjacent_assumption",
@@ -854,7 +854,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5819
+      "line": 5825
     },
     {
       "classification": "production_adjacent_assumption",
@@ -862,23 +862,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5827
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http.rs",
-      "kind": "expect_call",
-      "line": 5828
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http.rs",
-      "kind": "expect_call",
-      "line": 5830
+      "line": 5833
     },
     {
       "classification": "production_adjacent_assumption",
@@ -894,7 +878,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5838
+      "line": 5836
     },
     {
       "classification": "production_adjacent_assumption",
@@ -902,7 +886,15 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5839
+      "line": 5840
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http.rs",
+      "kind": "expect_call",
+      "line": 5844
     },
     {
       "classification": "production_adjacent_assumption",
@@ -918,7 +910,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5846
+      "line": 5851
     },
     {
       "classification": "production_adjacent_assumption",
@@ -926,7 +918,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5848
+      "line": 5852
     },
     {
       "classification": "production_adjacent_assumption",
@@ -934,15 +926,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5858
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http.rs",
-      "kind": "expect_call",
-      "line": 5861
+      "line": 5854
     },
     {
       "classification": "production_adjacent_assumption",
@@ -958,7 +942,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5866
+      "line": 5867
     },
     {
       "classification": "production_adjacent_assumption",
@@ -966,7 +950,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5888
+      "line": 5870
     },
     {
       "classification": "production_adjacent_assumption",
@@ -974,7 +958,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5914
+      "line": 5872
     },
     {
       "classification": "production_adjacent_assumption",
@@ -982,7 +966,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5923
+      "line": 5894
     },
     {
       "classification": "production_adjacent_assumption",
@@ -990,7 +974,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5924
+      "line": 5920
     },
     {
       "classification": "production_adjacent_assumption",
@@ -998,7 +982,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5926
+      "line": 5929
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1006,7 +990,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5936
+      "line": 5930
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1014,7 +998,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5939
+      "line": 5932
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1030,7 +1014,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5944
+      "line": 5945
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1038,7 +1022,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5959
+      "line": 5948
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1046,7 +1030,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5967
+      "line": 5950
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1054,7 +1038,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5968
+      "line": 5965
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1062,7 +1046,15 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5970
+      "line": 5973
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http.rs",
+      "kind": "expect_call",
+      "line": 5974
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1078,15 +1070,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5979
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http.rs",
-      "kind": "expect_call",
-      "line": 5983
+      "line": 5982
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1102,6 +1086,14 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
+      "line": 5989
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http.rs",
+      "kind": "expect_call",
       "line": 5991
     },
     {
@@ -1110,7 +1102,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5992
+      "line": 5997
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1118,7 +1110,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 5994
+      "line": 5998
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1134,14 +1126,6 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6003
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http.rs",
-      "kind": "expect_call",
       "line": 6006
     },
     {
@@ -1150,7 +1134,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6010
+      "line": 6009
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1166,7 +1150,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6192
+      "line": 6016
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1174,7 +1158,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6193
+      "line": 6018
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1182,7 +1166,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6194
+      "line": 6198
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1190,7 +1174,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6195
+      "line": 6199
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1198,7 +1182,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6248
+      "line": 6200
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1206,7 +1190,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6249
+      "line": 6201
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1214,7 +1198,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6250
+      "line": 6254
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1222,7 +1206,23 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6251
+      "line": 6255
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http.rs",
+      "kind": "expect_call",
+      "line": 6256
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http.rs",
+      "kind": "expect_call",
+      "line": 6257
     },
     {
       "classification": "panic_path_assumption",
@@ -1230,7 +1230,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "panic_macro",
-      "line": 6263
+      "line": 6269
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1238,7 +1238,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6265
+      "line": 6271
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1246,7 +1246,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6341
+      "line": 6347
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1254,7 +1254,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6350
+      "line": 6356
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1262,7 +1262,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http.rs",
       "kind": "expect_call",
-      "line": 6375
+      "line": 6381
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1350,7 +1350,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 578
+      "line": 586
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1358,7 +1358,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 579
+      "line": 587
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1366,31 +1366,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 581
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http_parse.rs",
-      "kind": "expect_call",
-      "line": 585
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http_parse.rs",
-      "kind": "expect_call",
-      "line": 588
-    },
-    {
-      "classification": "production_adjacent_assumption",
-      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
-      "fail_closed_relevance": "high",
-      "file": "src/http_parse.rs",
-      "kind": "expect_call",
-      "line": 591
+      "line": 589
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1406,7 +1382,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 604
+      "line": 596
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1414,7 +1390,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 611
+      "line": 599
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1422,7 +1398,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 614
+      "line": 601
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1430,7 +1406,7 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 650
+      "line": 612
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1438,7 +1414,23 @@
       "fail_closed_relevance": "high",
       "file": "src/http_parse.rs",
       "kind": "expect_call",
-      "line": 678
+      "line": 619
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http_parse.rs",
+      "kind": "expect_call",
+      "line": 622
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http_parse.rs",
+      "kind": "expect_call",
+      "line": 658
     },
     {
       "classification": "production_adjacent_assumption",
@@ -1447,6 +1439,30 @@
       "file": "src/http_parse.rs",
       "kind": "expect_call",
       "line": 686
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http_parse.rs",
+      "kind": "expect_call",
+      "line": 694
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http_parse.rs",
+      "kind": "expect_call",
+      "line": 811
+    },
+    {
+      "classification": "production_adjacent_assumption",
+      "disposition": "convert_to_explicit_error_or_fail_closed_response_in_later_slice",
+      "fail_closed_relevance": "high",
+      "file": "src/http_parse.rs",
+      "kind": "expect_call",
+      "line": 825
     },
     {
       "classification": "production_adjacent_assumption",
@@ -5857,7 +5873,7 @@
       "line": 521
     }
   ],
-  "generated_at_utc": "2026-07-29T19:48:23Z",
+  "generated_at_utc": "2026-08-16T14:24:29Z",
   "non_claims": [
     "This audit does not claim that all Rust assumptions are safe.",
     "This audit does not claim that production request paths are panic-free.",
@@ -5897,26 +5913,26 @@
     "by_classification": {
       "control_flow_invariant": 2,
       "panic_path_assumption": 28,
-      "production_adjacent_assumption": 626,
+      "production_adjacent_assumption": 628,
       "test_or_fixture_assumption": 76
     },
     "by_fail_closed_relevance": {
-      "high": 654,
+      "high": 656,
       "low": 76,
       "medium": 2
     },
     "by_kind": {
-      "expect_call": 690,
+      "expect_call": 692,
       "panic_macro": 34,
       "unreachable_macro": 2,
       "unwrap_call": 6
     },
     "classification_complete": true,
-    "inventory_sha256": "7169a1aef3250ef58f289bc42938117ed9ac308ea9da748dbb7c9293b651e8d7",
+    "inventory_sha256": "9a10c21ec381b69b67183145570b2b7a0dfdc8bb078161523b452e58502adc71",
     "live_host_state_changed": false,
     "product_behavior_changed": false,
     "production_state_changed": false,
     "slice0_carried_forward_rust_assumption_count": 712,
-    "total_count": 732
+    "total_count": 734
   }
 }

--- a/maint/security/v15-http-differential-corpus.json
+++ b/maint/security/v15-http-differential-corpus.json
@@ -6,15 +6,15 @@
       "id": "valid_get",
       "rationale": "Canonical unauthenticated GET control.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "ACCEPT",
+      "required_edge_policy": "FORWARD_EXACTLY_ONE",
       "required_origin_policy": "ACCEPT"
     },
     {
       "class": "control",
       "id": "valid_post_content_length_zero",
-      "rationale": "Canonical zero-length POST parser control; route status is measured.",
+      "rationale": "Canonical zero-length POST must reach the origin once; its application status is recorded separately.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "MEASURE",
+      "required_edge_policy": "FORWARD_EXACTLY_ONE",
       "required_origin_policy": "ACCEPT"
     },
     {
@@ -22,15 +22,15 @@
       "id": "leading_request_line_whitespace",
       "rationale": "Strict request-line policy rejects leading whitespace.",
       "request_template": " GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "request_line",
       "id": "double_space_request_line",
-      "rationale": "Strict request-line policy requires one SP separator.",
+      "rationale": "The strict origin rejects the raw line while the edge may safely canonicalize it into one equivalent request.",
       "request_template": "GET  /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -38,23 +38,23 @@
       "id": "tab_request_line_separator",
       "rationale": "HTAB request-line separators are a parser-differential risk.",
       "request_template": "GET\t/login?osmap_s03={token}\tHTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "line_termination",
       "id": "bare_lf_header_lines",
-      "rationale": "OSMAP requires CRLF framing.",
+      "rationale": "OSMAP requires CRLF; the edge may safely canonicalize one unambiguous message.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\nHost: {authority}\nConnection: close\n\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "line_termination",
       "id": "mixed_crlf_lf",
-      "rationale": "Mixed line termination must fail closed.",
+      "rationale": "The origin rejects mixed termination while the edge may canonicalize one unambiguous message.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -62,7 +62,7 @@
       "id": "obs_fold_header",
       "rationale": "Obsolete folded fields must not be interpreted differently.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX-Test: one\r\n two\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -70,7 +70,7 @@
       "id": "whitespace_before_colon",
       "rationale": "RFC 9112 requires rejection of whitespace before colon.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost : {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -78,31 +78,31 @@
       "id": "space_in_field_name",
       "rationale": "SP is not a valid field-name byte.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX Bad: value\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "edge_difference",
       "id": "underscore_field_name",
-      "rationale": "Measure nginx invalid-header policy versus OSMAP tchar handling.",
+      "rationale": "OSMAP retains its narrow field-name allowlist; the edge may discard this unused field while forwarding one equivalent request.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX_Test: value\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "MEASURE",
-      "required_origin_policy": "MEASURE"
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
+      "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "edge_difference",
       "id": "dot_in_field_name",
-      "rationale": "Measure edge forwarding of a field name OSMAP accepts.",
+      "rationale": "OSMAP retains its narrow field-name allowlist; the edge may discard this unused field while forwarding one equivalent request.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX.Test: value\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "MEASURE",
-      "required_origin_policy": "MEASURE"
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
+      "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "host",
       "id": "missing_host",
       "rationale": "HTTP/1.1 requires Host.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -110,7 +110,7 @@
       "id": "empty_host",
       "rationale": "Empty authority must fail closed.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost:\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -118,7 +118,7 @@
       "id": "duplicate_host_same",
       "rationale": "Duplicate Host is rejected even when values agree.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -126,7 +126,7 @@
       "id": "duplicate_host_conflicting",
       "rationale": "Conflicting authority is a routing differential.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nHost: attacker.invalid\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -134,7 +134,7 @@
       "id": "host_with_path",
       "rationale": "Host must not contain path characters.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}/admin\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -142,7 +142,7 @@
       "id": "duplicate_content_length_same",
       "rationale": "OSMAP rejects every duplicate framing field.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -150,39 +150,39 @@
       "id": "duplicate_content_length_conflicting",
       "rationale": "Conflicting lengths are a request-smuggling primitive.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "framing",
       "id": "comma_content_length_same",
-      "rationale": "Measure comma-list normalisation differences.",
+      "rationale": "OSMAP deliberately rejects comma-list framing and the edge must reject it before origin.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0, 0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "MEASURE",
-      "required_origin_policy": "MEASURE"
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "framing",
       "id": "comma_content_length_conflicting",
       "rationale": "Conflicting comma-list lengths must fail closed.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0, 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "framing",
       "id": "malformed_content_length_plus",
-      "rationale": "Measure plus-sign integer parsing across recipients.",
+      "rationale": "Content-Length admits ASCII decimal digits only at both recipients.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: +0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "MEASURE",
-      "required_origin_policy": "MEASURE"
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "framing",
       "id": "malformed_content_length_hex",
       "rationale": "Hex-like lengths must be rejected.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0x0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -190,7 +190,7 @@
       "id": "transfer_encoding_chunked",
       "rationale": "OSMAP does not admit Transfer-Encoding.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -198,7 +198,7 @@
       "id": "transfer_encoding_obfuscated",
       "rationale": "Transfer-coding chains must fail closed.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nTransfer-Encoding: chunked, identity\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -206,7 +206,7 @@
       "id": "content_length_plus_transfer_encoding",
       "rationale": "CL plus TE is a primary desynchronisation shape.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 4\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -214,7 +214,7 @@
       "id": "truncated_declared_body",
       "rationale": "Early close before declared body completion must reject.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 4\r\nConnection: close\r\n\r\nab",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -222,15 +222,15 @@
       "id": "extra_bytes_after_declared_body",
       "rationale": "Bytes beyond the declared body must not become a second message.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "pipelining",
       "id": "pipelined_second_request",
-      "rationale": "The sequential listener admits exactly one request per connection.",
+      "rationale": "The edge may forward only the first complete request and must close before queued bytes create a second origin request.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: keep-alive\r\n\r\nGET /login?osmap_s03={token}-second HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "FORWARD_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -238,7 +238,7 @@
       "id": "get_with_declared_body",
       "rationale": "GET bodies are outside OSMAP's accepted browser surface.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -246,7 +246,7 @@
       "id": "post_without_content_length",
       "rationale": "POST requires explicit Content-Length.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -254,7 +254,7 @@
       "id": "target_fragment",
       "rationale": "Fragments are not valid origin-form request targets.",
       "request_template": "GET /login?osmap_s03={token}#fragment HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -262,7 +262,7 @@
       "id": "target_dot_segments",
       "rationale": "OSMAP requires normalized request targets.",
       "request_template": "GET /a/../login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -270,7 +270,7 @@
       "id": "target_double_slash",
       "rationale": "Multiple path separators are rejected rather than normalized.",
       "request_template": "GET /login//?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -281,7 +281,7 @@
       },
       "id": "oversized_request_line",
       "rationale": "Exceeds OSMAP's 2048-byte request-target policy.",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -291,9 +291,9 @@
         "value_bytes": 9000
       },
       "id": "oversized_header_field",
-      "rationale": "Measure nginx field-buffer policy versus OSMAP's block-level cap.",
-      "required_edge_policy": "MEASURE",
-      "required_origin_policy": "MEASURE"
+      "rationale": "A field value above OSMAP's 8 KiB per-field limit must be rejected at both recipients.",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "limits",
@@ -303,10 +303,10 @@
       },
       "id": "oversized_header_block",
       "rationale": "Exceeds OSMAP's 16 KiB total header policy.",
-      "required_edge_policy": "REJECT_OR_CLOSE",
+      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
       "required_origin_policy": "REJECT_CLOSE"
     }
   ],
-  "schema": "osmap-v15-http-differential-corpus-v1",
+  "schema": "osmap-v15-http-differential-corpus-v2",
   "standards_boundary": "RFC 9112 HTTP/1.1 message syntax and routing"
 }

--- a/maint/security/v15-http-differential-corpus.json
+++ b/maint/security/v15-http-differential-corpus.json
@@ -22,7 +22,7 @@
       "id": "leading_request_line_whitespace",
       "rationale": "Strict request-line policy rejects leading whitespace.",
       "request_template": " GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -38,7 +38,7 @@
       "id": "tab_request_line_separator",
       "rationale": "HTAB request-line separators are a parser-differential risk.",
       "request_template": "GET\t/login?osmap_s03={token}\tHTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -62,7 +62,7 @@
       "id": "obs_fold_header",
       "rationale": "Obsolete folded fields must not be interpreted differently.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX-Test: one\r\n two\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -70,7 +70,7 @@
       "id": "whitespace_before_colon",
       "rationale": "RFC 9112 requires rejection of whitespace before colon.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost : {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -78,7 +78,7 @@
       "id": "space_in_field_name",
       "rationale": "SP is not a valid field-name byte.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nX Bad: value\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -102,7 +102,7 @@
       "id": "missing_host",
       "rationale": "HTTP/1.1 requires Host.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -110,7 +110,7 @@
       "id": "empty_host",
       "rationale": "Empty authority must fail closed.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost:\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -118,7 +118,7 @@
       "id": "duplicate_host_same",
       "rationale": "Duplicate Host is rejected even when values agree.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -126,7 +126,7 @@
       "id": "duplicate_host_conflicting",
       "rationale": "Conflicting authority is a routing differential.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nHost: attacker.invalid\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -134,7 +134,7 @@
       "id": "host_with_path",
       "rationale": "Host must not contain path characters.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}/admin\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -142,7 +142,7 @@
       "id": "duplicate_content_length_same",
       "rationale": "OSMAP rejects every duplicate framing field.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -150,7 +150,7 @@
       "id": "duplicate_content_length_conflicting",
       "rationale": "Conflicting lengths are a request-smuggling primitive.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -166,7 +166,7 @@
       "id": "comma_content_length_conflicting",
       "rationale": "Conflicting comma-list lengths must fail closed.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0, 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -182,15 +182,15 @@
       "id": "malformed_content_length_hex",
       "rationale": "Hex-like lengths must be rejected.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0x0\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "framing",
       "id": "transfer_encoding_chunked",
-      "rationale": "OSMAP does not admit Transfer-Encoding.",
+      "rationale": "OSMAP rejects raw Transfer-Encoding while the edge may dechunk one unambiguous message.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -198,7 +198,7 @@
       "id": "transfer_encoding_obfuscated",
       "rationale": "Transfer-coding chains must fail closed.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nTransfer-Encoding: chunked, identity\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -206,7 +206,7 @@
       "id": "content_length_plus_transfer_encoding",
       "rationale": "CL plus TE is a primary desynchronisation shape.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 4\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -214,15 +214,15 @@
       "id": "truncated_declared_body",
       "rationale": "Early close before declared body completion must reject.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 4\r\nConnection: close\r\n\r\nab",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
       "class": "body",
       "id": "extra_bytes_after_declared_body",
-      "rationale": "Bytes beyond the declared body must not become a second message.",
+      "rationale": "Bytes beyond the declared body may be discarded only when exactly one equivalent request reaches the origin.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 0\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "CANONICALIZE_EXACTLY_ONE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -238,7 +238,7 @@
       "id": "get_with_declared_body",
       "rationale": "GET bodies are outside OSMAP's accepted browser surface.",
       "request_template": "GET /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nX",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -246,7 +246,7 @@
       "id": "post_without_content_length",
       "rationale": "POST requires explicit Content-Length.",
       "request_template": "POST /login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -254,7 +254,7 @@
       "id": "target_fragment",
       "rationale": "Fragments are not valid origin-form request targets.",
       "request_template": "GET /login?osmap_s03={token}#fragment HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -262,7 +262,7 @@
       "id": "target_dot_segments",
       "rationale": "OSMAP requires normalized request targets.",
       "request_template": "GET /a/../login?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -270,7 +270,7 @@
       "id": "target_double_slash",
       "rationale": "Multiple path separators are rejected rather than normalized.",
       "request_template": "GET /login//?osmap_s03={token} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\n\r\n",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -281,7 +281,7 @@
       },
       "id": "oversized_request_line",
       "rationale": "Exceeds OSMAP's 2048-byte request-target policy.",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     },
     {
@@ -303,7 +303,7 @@
       },
       "id": "oversized_header_block",
       "rationale": "Exceeds OSMAP's 16 KiB total header policy.",
-      "required_edge_policy": "REJECT_BEFORE_ORIGIN",
+      "required_edge_policy": "REJECT_OR_FORWARD_ONCE",
       "required_origin_policy": "REJECT_CLOSE"
     }
   ],

--- a/src/http.rs
+++ b/src/http.rs
@@ -117,6 +117,9 @@ pub const DEFAULT_HTTP_MAX_FORM_FIELDS: usize = 16;
 /// Conservative upper bound for header count in one request.
 pub const DEFAULT_HTTP_MAX_HEADER_COUNT: usize = 64;
 
+/// Conservative upper bound for any individual request-header value.
+pub const DEFAULT_HTTP_MAX_HEADER_VALUE_BYTES: usize = 8 * 1024;
+
 /// Conservative upper bound for the `Host` header value.
 pub const DEFAULT_HTTP_MAX_HOST_HEADER_BYTES: usize = 512;
 
@@ -169,6 +172,7 @@ pub struct HttpPolicy {
     pub max_header_bytes: usize,
     pub max_request_target_bytes: usize,
     pub max_header_count: usize,
+    pub max_header_value_bytes: usize,
     pub max_query_fields: usize,
     pub max_body_bytes: usize,
     pub max_upload_body_bytes: usize,
@@ -195,6 +199,7 @@ impl HttpPolicy {
             max_header_bytes: DEFAULT_HTTP_MAX_HEADER_BYTES,
             max_request_target_bytes: DEFAULT_HTTP_MAX_REQUEST_TARGET_BYTES,
             max_header_count: DEFAULT_HTTP_MAX_HEADER_COUNT,
+            max_header_value_bytes: DEFAULT_HTTP_MAX_HEADER_VALUE_BYTES,
             max_query_fields: DEFAULT_HTTP_MAX_QUERY_FIELDS,
             max_body_bytes: DEFAULT_HTTP_MAX_BODY_BYTES,
             max_upload_body_bytes: DEFAULT_HTTP_MAX_UPLOAD_BODY_BYTES,
@@ -225,6 +230,7 @@ impl Default for HttpPolicy {
             max_header_bytes: DEFAULT_HTTP_MAX_HEADER_BYTES,
             max_request_target_bytes: DEFAULT_HTTP_MAX_REQUEST_TARGET_BYTES,
             max_header_count: DEFAULT_HTTP_MAX_HEADER_COUNT,
+            max_header_value_bytes: DEFAULT_HTTP_MAX_HEADER_VALUE_BYTES,
             max_query_fields: DEFAULT_HTTP_MAX_QUERY_FIELDS,
             max_body_bytes: DEFAULT_HTTP_MAX_BODY_BYTES,
             max_upload_body_bytes: DEFAULT_HTTP_MAX_UPLOAD_BODY_BYTES,

--- a/src/http_parse.rs
+++ b/src/http_parse.rs
@@ -391,6 +391,11 @@ fn parse_headers(
         }
 
         let normalized_value = value.trim().to_string();
+        if normalized_value.len() > policy.max_header_value_bytes {
+            return Err(parse_error(format!(
+                "http header value for {normalized_name} exceeded maximum length"
+            )));
+        }
         if normalized_value.chars().any(char::is_control) {
             return Err(parse_error(format!(
                 "http header value for {normalized_name} contained control characters"
@@ -449,6 +454,9 @@ fn parse_content_length_from_headers(
     headers
         .get("content-length")
         .map(|value| {
+            if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(parse_error("invalid content-length header"));
+            }
             value
                 .parse::<usize>()
                 .map_err(|_| parse_error("invalid content-length header"))
@@ -780,6 +788,48 @@ mod tests {
         assert_eq!(
             parse_error_reason(request, &HttpPolicy::default()),
             "http header block contained non-crlf line endings"
+        );
+    }
+
+    #[test]
+    fn content_length_requires_ascii_decimal_digits_only() {
+        for value in ["+0", "-0", "0 0", "0,0", "0x0", ""] {
+            let request = format!(
+                "POST /login HTTP/1.1\r\nHost: localhost\r\nContent-Length: {value}\r\n\r\n"
+            );
+            assert_eq!(
+                parse_error_reason(request.as_bytes(), &HttpPolicy::default()),
+                "invalid content-length header",
+                "value {value:?} must be rejected"
+            );
+        }
+
+        let parsed = crate::http::parse_http_request_bytes(
+            b"POST /login HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n",
+            &HttpPolicy::default(),
+        )
+        .expect("an ASCII-decimal zero content length should parse");
+        assert!(parsed.body.is_empty());
+    }
+
+    #[test]
+    fn enforces_generic_header_value_limit() {
+        let accepted_value = "a".repeat(8);
+        let accepted =
+            format!("GET /login HTTP/1.1\r\nHost: x\r\nX-Test: {accepted_value}\r\n\r\n");
+        let policy = HttpPolicy {
+            max_header_value_bytes: 8,
+            ..HttpPolicy::default()
+        };
+        crate::http::parse_http_request_bytes(accepted.as_bytes(), &policy)
+            .expect("a header value exactly at the limit should parse");
+
+        let rejected_value = "a".repeat(9);
+        let rejected =
+            format!("GET /login HTTP/1.1\r\nHost: x\r\nX-Test: {rejected_value}\r\n\r\n");
+        assert_eq!(
+            parse_error_reason(rejected.as_bytes(), &policy),
+            "http header value for x-test exceeded maximum length"
         );
     }
 }


### PR DESCRIPTION
Closes #55.

## What changed

- require ASCII-decimal-only `Content-Length` and an 8 KiB generic header-value limit;
- replace all observation-only corpus policies with deterministic origin, edge, canonicalization, and cardinality policies;
- record raw edge/direct-origin observations, token-correlated forwarding, and application outcomes separately;
- close OSMAP client connections after one nginx response so pipelined bytes cannot create a second origin request;
- add focused Rust, harness, host-artifact, and isolated nginx regression coverage;
- preserve the Slice 03 evidence and document the bounded Slice 04 deployment and rollback state.

## Validation

- full `make acceptance-check` passed twice on exact tree `9d7e6057982a52c75aaaa3835a59690cd4b3cac6` on `mail`;
- full Rust suite: 545 passed, 4 ignored, 0 failed, plus all integration and doc tests;
- clippy with warnings denied and rustfmt passed;
- offline and live 37-case required-policy campaigns both passed with:
  - `required_policy_failures=0`
  - `measured_unique_cases=0`
  - `origin_request_cardinality_violations=0`
- nginx syntax, `osmap_serve`, `osmap_mailbox_helper`, and TLS/direct health controls passed after deployment.

## Evidence

- archive: `osmap-v15-slice04-evidence-6e28ae4.tar.gz`
- SHA-256: `de1a823e21c7a5014ec840c132d9e77b5759b03186727947f51cd5947d16fb6d`
- deployed binary SHA-256: `d7426c8b51bed05f535da7195246a04365c3c5f39967a0170e64f350761cc85e`
- all four commits verify with required fingerprint `F55E404E91A0753701F91B01A7228D3FB5084B34`.
